### PR TITLE
Update the lastMessageAt when message received

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -985,6 +985,13 @@ static BOOL AVIMClientHasInstantiated = NO;
     __weak typeof(self) ws = self;
     
     [self fetchConversationIfNeeded:conversation withBlock:^(AVIMConversation *conversation) {
+        /* Update lastMessageAt if needed. */
+        NSDate *messageSentAt = [NSDate dateWithTimeIntervalSince1970:(message.sendTimestamp / 1000.0)];
+
+        if (!conversation.lastMessageAt || [conversation.lastMessageAt compare:messageSentAt] == NSOrderedAscending) {
+            conversation.lastMessageAt = messageSentAt;
+        }
+
         [ws passMessage:message toConversation:conversation];
     }];
 }


### PR DESCRIPTION
当客户端收到消息时，使用消息的发送时间来更新对话的 `lastMessageAt`。解决因缓存而导致的 `lastMessageAt` 不能及时更新的情况。 @leancloud/ios-group @nicecui 