### PR TITLE
Reset property when remove object for key

### DIFF
--- a/AVOS/AVOSCloud/Object/AVObject.m
+++ b/AVOS/AVOSCloud/Object/AVObject.m
@@ -358,6 +358,11 @@ BOOL requests_contain_request(NSArray *requests, NSDictionary *request) {
         }
         [dic removeObjectForKey:key];
     }
+    if ([AVUtils containsProperty:key inClass:[self class] containSuper:YES filterDynamic:YES]) {
+        /* Create a clean object to produce an empty value. */
+        [self setValue:[[[self class] alloc] valueForKey:key] forKey:key];
+        hasKey = YES;
+    }
     if (hasKey || [self hasValidObjectId]) {
         [self.requestManager unsetRequestForKey:key];
     }


### PR DESCRIPTION
删除某个 key 时，同时将属性置空。修复了 #52 的问题。 @leancloud/ios-group @nicecui 