### PR TITLE
Fix router info table mutated while being enumerated

### DIFF
--- a/AVOS/AVOSCloud/Router/LCRouterCache.m
+++ b/AVOS/AVOSCloud/Router/LCRouterCache.m
@@ -102,7 +102,8 @@ extern NSString *LCTTLKey;
 }
 
 - (void)save {
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self.routerInfoTable];
+    NSDictionary *routerInfoTable = [[NSDictionary alloc] initWithDictionary:self.routerInfoTable copyItems:YES];
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:routerInfoTable];
     [[LCKeyValueStore sharedInstance] setData:data forKey:LCRouterKey];
 }
 


### PR DESCRIPTION
修复 router 信息缓存时的错误。修复了 #47 的问题。 @leancloud/ios-group 