### PR TITLE
Fix crash when dequeue command for nil key

### DIFF
--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -664,6 +664,8 @@ SecCertificateRef LCGetCertificateFromBase64String(NSString *base64);
 }
 
 - (AVIMGenericCommand *)dequeueCommandWithId:(NSNumber *)num {
+    if (!num)
+        return nil;
     AVIMCommandCarrier *carrier = [_commandDictionary objectForKey:num];
     AVIMGenericCommand *command = carrier.command;
     [_commandDictionary removeObjectForKey:num];


### PR DESCRIPTION
修复 WebSocket wrapper 在 dequeue command 时崩溃的问题。