### PR TITLE
Deprecate device token registration methods

### DIFF
--- a/AVOS/AVOSCloud/AVOSCloud.h
+++ b/AVOS/AVOSCloud/AVOSCloud.h
@@ -294,7 +294,8 @@ typedef NS_ENUM(NSInteger, AVServiceRegion) {
 /**
  * Register remote notification with all types (badge, alert, sound) and empty categories.
  */
-+ (void)registerForRemoteNotification AV_TV_UNAVAILABLE AV_WATCH_UNAVAILABLE;
++ (void)registerForRemoteNotification AV_TV_UNAVAILABLE AV_WATCH_UNAVAILABLE
+    AV_DEPRECATED("Deprecated in AVOSCloud SDK 3.5.0. It will be removed in future.");
 
 /**
  * Register remote notification with types.
@@ -302,7 +303,8 @@ typedef NS_ENUM(NSInteger, AVServiceRegion) {
  * @param categories A set of UIUserNotificationCategory objects that define the groups of actions a notification may include.
  * NOTE: categories only supported by iOS 8 and later. If application run below iOS 8, categories will be ignored.
  */
-+ (void)registerForRemoteNotificationTypes:(NSUInteger)types categories:(NSSet *)categories AV_TV_UNAVAILABLE AV_WATCH_UNAVAILABLE;
++ (void)registerForRemoteNotificationTypes:(NSUInteger)types categories:(NSSet *)categories AV_TV_UNAVAILABLE AV_WATCH_UNAVAILABLE
+    AV_DEPRECATED("Deprecated in AVOSCloud SDK 3.5.0. It will be removed in future.");
 
 /**
  * Handle device token registered from APNs.

--- a/AVOS/AVOSCloudIM/AVOSCloudIM.h
+++ b/AVOS/AVOSCloudIM/AVOSCloudIM.h
@@ -37,7 +37,7 @@
  * Register remote notification with all types (badge, alert, sound) and empty categories.
  */
 + (void)registerForRemoteNotification AVIM_TV_UNAVAILABLE AVIM_WATCH_UNAVAILABLE \
-    AVIM_DEPRECATED("Deprecated in AVOSCloud SDK 3.2.8. Use +[AVOSCloud registerForRemoteNotification] instead.");
+    AVIM_DEPRECATED("Deprecated in AVOSCloud SDK 3.2.8. It will be removed in future.");
 
 /**
  * Register remote notification with types.
@@ -46,7 +46,7 @@
  * NOTE: categories only supported by iOS 8 and later. If application run below iOS 8, categories will be ignored.
  */
 + (void)registerForRemoteNotificationTypes:(NSUInteger)types categories:(NSSet *)categories AVIM_TV_UNAVAILABLE AVIM_WATCH_UNAVAILABLE \
-    AVIM_DEPRECATED("Deprecated in AVOSCloud SDK 3.2.8. Use +[AVOSCloud registerForRemoteNotificationTypes:categories:] instead.");
+    AVIM_DEPRECATED("Deprecated in AVOSCloud SDK 3.2.8. It will be removed in future.");
 
 /**
  * Handle device token registered from APNs.


### PR DESCRIPTION
废除 device token 注册的方法，具体原因见 #63.

@leancloud/ios-group @leancloud/tech-support