### PR TITLE
Change persistence path

### DIFF
--- a/AVOS/AVOSCloudTests/LogicTests/AVPersistentUtilsTest.m
+++ b/AVOS/AVOSCloudTests/LogicTests/AVPersistentUtilsTest.m
@@ -23,28 +23,23 @@
     [super tearDown];
 }
 
-- (void)assertPath:(NSString *)path equalToRelativePath:(NSString *)relativePath {
-    NSString *home = NSHomeDirectory();
-#if AV_OSX_ONLY
-    home = [home stringByAppendingPathComponent:[NSString stringWithFormat:@"Library/Application Support/LeanCloud/%@", [AVOSCloud getApplicationId]]];
-#endif
-    path = [path stringByReplacingOccurrencesOfString:home withString:@"~"];
-    XCTAssertEqualObjects(path, relativePath);
+- (void)assertPath:(NSString *)path hasSuffix:(NSString *)suffix {
+    XCTAssertTrue([path hasSuffix:suffix]);
 }
 
 - (void)testCurrentUserArchivePath {
     NSString *path = [AVPersistenceUtils currentUserArchivePath];
-    [self assertPath:path equalToRelativePath:@"~/Library/Private Documents/AVPaas/currentUser"];
+    [self assertPath:path hasSuffix:@"Private Documents/AVPaas/currentUser"];
 }
 
 - (void)testMessageCacheDatabasePath {
-    NSString *path = [AVPersistenceUtils messageCacheDatabasePathWithName:@"chat"];
-    [self assertPath:path equalToRelativePath:@"~/Library/Caches/LeanCloud/MessageCache/chat"];
+    NSString *path = [AVPersistenceUtils messageCacheDatabasePathWithName:@"Chat"];
+    [self assertPath:path hasSuffix:@"Caches/MessageCache/Chat"];
 }
 
 - (void)testCommandCacheDatabasePath {
     NSString *path = [AVPersistenceUtils commandCacheDatabasePath];
-    [self assertPath:path equalToRelativePath:@"~/Documents/LeanCloud/CommandCache"];
+    [self assertPath:path hasSuffix:@"Caches/CommandCache"];
 }
 
 @end


### PR DESCRIPTION
将 SDK 的持久化路径转移到 "Application Support" 目录下。

一直以来，持久化数据都放在 Documents 目录下。但 Documents 目录是可以共享给用户的，这样一来，SDK 的一些隐私数据就会暴露给最终用户，这是不期望的。

但是，这个改进带来的副作用是 SDK 会丢弃之前所缓存的数据。带来的后果是：缓存数据会重新拉取、currentUser 会丢失，用户要重新登录，等等。

这个 PR 目前是单独给我们的客户定制的。但从长远来看，应该合并。需要观察一段时间。

**Review 后暂时不要合并**。 @leancloud/ios-group 
