### PR TITLE
Make sure callback can always be called when client did close

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -260,13 +260,13 @@ static BOOL AVIMClientHasInstantiated = NO;
 }
 
 - (void)sendCommand:(AVIMGenericCommand *)command {
-    if (_socketWrapper) {
-        switch (_status) {
-        case AVIMClientStatusClosing:
-        case AVIMClientStatusClosed: return;
-        default: break;
-        }
+    BOOL sendable = (
+        _socketWrapper != nil &&
+        _status != AVIMClientStatusClosing &&
+        _status != AVIMClientStatusClosed
+    );
 
+    if (sendable) {
         [_socketWrapper sendCommand:command];
     } else {
         AVIMCommandResultBlock callback = command.callback;


### PR DESCRIPTION
修复当 client 处于关闭状态，应用尝试再次关闭 client 时，callback 不会被调用的问题。

@leancloud/ios-group 