### PR TITLE
Add shortcut to get roles that current user belongs to

### DIFF
--- a/AVOS/AVOSCloud/User/AVUser.h
+++ b/AVOS/AVOSCloud/User/AVUser.h
@@ -6,6 +6,7 @@
 #import "AVObject.h"
 #import "AVSubclassing.h"
 
+@class AVRole;
 @class AVQuery;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -122,6 +123,22 @@ A LeanCloud Framework User Object that is a local representation of a user persi
  *  @param block 回调结果
  */
 +(void)verifyMobilePhone:(NSString *)code withBlock:(AVBooleanResultBlock)block;
+
+/*!
+ Get roles which current user belongs to.
+
+ @param error The error of request, or nil if request did succeed.
+
+ @return An array of roles, or nil if some error occured.
+ */
+- (nullable NSArray<AVRole *> *)getRoles:(NSError **)error;
+
+/*!
+ Asynchronously get roles which current user belongs to.
+
+ @param block The callback for request.
+ */
+- (void)getRolesInBackgroundWithBlock:(void (^)(NSArray<AVRole *> * _Nullable objects, NSError * _Nullable error))block;
 
 /*!
  Signs up the user. Make sure that password and username are set. This will also enforce that the username isn't already taken.

--- a/AVOS/AVOSCloud/User/AVUser.m
+++ b/AVOS/AVOSCloud/User/AVUser.m
@@ -103,6 +103,19 @@ static BOOL enableAutomatic = NO;
     return[dict allKeys];
 }
 
+- (NSArray<AVRole *> *)getRoles:(NSError * _Nullable __autoreleasing *)error {
+    AVQuery *query = [AVRelation reverseQuery:@"_Role" relationKey:@"users" childObject:self];
+    return [query findObjects:error];
+}
+
+- (void)getRolesInBackgroundWithBlock:(void (^)(NSArray<AVRole *> * _Nullable, NSError * _Nullable))block {
+    [AVUtils asynchronizeTask:^{
+        NSError *error = nil;
+        NSArray<AVRole *> *result = [self getRoles:&error];
+        [AVUtils callArrayResultBlock:block array:result error:error];
+    }];
+}
+
 + (instancetype)user
 {
     AVUser *u = [[[self class] alloc] initWithClassName:[[self class] userTag]];

--- a/AVOS/AVOSCloud/Utils/AVUtils.h
+++ b/AVOS/AVOSCloud/Utils/AVUtils.h
@@ -102,6 +102,13 @@ SecCertificateRef LCGetCertificateFromBase64String(NSString *base64);
                           result:(AVCloudQueryResult *)result
                            error:error;
 
+/*!
+ Dispatch task on background thread.
+
+ @param task The task to be dispatched.
+ */
++ (void)asynchronizeTask:(void(^)())task;
+
 #pragma mark - String Util
 + (NSString *)MIMEType:(NSString *)filePathOrName;
 + (NSString *)MIMETypeFromPath:(NSString *)fullPath;

--- a/AVOS/AVOSCloud/Utils/AVUtils.m
+++ b/AVOS/AVOSCloud/Utils/AVUtils.m
@@ -514,6 +514,28 @@ if (block) { \
     safeBlock(result);
 }
 
++ (dispatch_queue_t)asynchronousTaskQueue {
+    static dispatch_queue_t queue;
+    static dispatch_once_t onceToken;
+
+    if (queue)
+        return queue;
+
+    dispatch_once(&onceToken, ^{
+        queue = dispatch_queue_create("avos.common.dispatchQueue", DISPATCH_QUEUE_CONCURRENT);
+    });
+
+    return queue;
+}
+
++ (void)asynchronize:(void (^)())task {
+    NSAssert(task != nil, @"Task cannot be nil.");
+
+    dispatch_async([self asynchronousTaskQueue], ^{
+        task();
+    });
+}
+
 #pragma mark - String Util
 + (NSString *)MIMEType:(NSString *)filePathOrName {
     CFStringRef UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)[filePathOrName pathExtension], NULL);

--- a/AVOS/AVOSCloudTests/LogicTests/AVUserTest.m
+++ b/AVOS/AVOSCloudTests/LogicTests/AVUserTest.m
@@ -380,4 +380,46 @@
     WAIT
 }
 
+- (AVUser *)signUpRandomUser {
+    AVUser *user  = [[AVUser alloc] init];
+
+    user.username = [@"foo" stringByAppendingFormat:@"%ld", (long)arc4random()];
+    user.password = [@"bar" stringByAppendingFormat:@"%ld", (long)arc4random()];
+
+    NSError *error = nil;
+    [user signUp:&error];
+
+    XCTAssert(!error, @"%@", error);
+
+    return user;
+}
+
+- (void)testGetRoles {
+    AVUser *user = [self signUpRandomUser];
+    AVRole *role = [AVRole roleWithName:[@"testRole" stringByAppendingFormat:@"%ld", (long)arc4random()]];
+
+    AVACL *acl = [AVACL ACL];
+    [acl setPublicReadAccess:YES];
+    [acl setWriteAccess:YES forUser:user];
+
+    role.ACL = acl;
+    [role.users addObject:user];
+
+    NSError *error1 = nil;
+    [role save:&error1];
+
+    XCTAssertTrue(error1 == nil, @"%@", error1);
+
+    NSError *error2 = nil;
+    NSArray<AVRole *> *roles = [user getRoles:&error2];
+
+    XCTAssertTrue(error2 == nil, @"%@", error2);
+
+    XCTAssertEqual(roles.count, 1);
+    XCTAssertTrue([[[roles firstObject] objectId] isEqualToString:role.objectId]);
+
+    [role delete];
+    [user delete];
+}
+
 @end


### PR DESCRIPTION
添加 AVUser#getRoles() 方法来获取用户所属的角色。不过由于 AVQuery 的查询限制，理论上目前只能查询最多 100 个角色。 @leancloud/ios-group 