### PR TITLE
Remove some reserved keys

### DIFF
--- a/AVOS/AVOSCloudTests/LogicTests/AVObjectTest.m
+++ b/AVOS/AVOSCloudTests/LogicTests/AVObjectTest.m
@@ -749,21 +749,17 @@ const void *AVObjectTestDeleteAll = &AVObjectTestDeleteAll;
     NSString *className = @"TestObject";
     AVObject *object = [AVObject objectWithClassName:className];
     XCTAssertNoThrow([object setObject:@"test string" forKey:@"string"]);
-    NSArray *invalidKeys = @[@"code",
-                             @"uuid",
-                             @"className",
-                             @"keyValues",
-                             @"fetchWhenSave",
-                             @"running",
-                             @"acl",
-                             @"ACL",
-                             @"pendingKeys",
-                             @"createdAt",
-                             @"updatedAt",
-                             @"objectId"];
+    NSArray *invalidKeys = @[
+        @"objectId",
+        @"createdAt",
+        @"updatedAt"
+    ];
     for (NSString *key in invalidKeys) {
         XCTAssertThrows([object setObject:@"test object" forKey:key]);
     }
+    XCTAssertThrows([object setObject:@"String" forKey:@"ACL"]);
+    [object setObject:[AVACL ACL] forKey:@"ACL"];
+    [object setObject:nil forKey:@"ACL"];
 }
 
 - (void)testRemoveObjectForKey {
@@ -786,21 +782,17 @@ const void *AVObjectTestDeleteAll = &AVObjectTestDeleteAll;
     NSString *className = @"TestObject";
     AVObject *object = [AVObject objectWithClassName:className];
     XCTAssertNoThrow(object[@"string"] = @"test string");
-    NSArray *invalidKeys = @[@"code",
-                             @"uuid",
-                             @"className",
-                             @"keyValues",
-                             @"fetchWhenSave",
-                             @"running",
-                             @"acl",
-                             @"ACL",
-                             @"pendingKeys",
-                             @"createdAt",
-                             @"updatedAt",
-                             @"objectId"];
+    NSArray *invalidKeys = @[
+        @"objectId",
+        @"createdAt",
+        @"updatedAt"
+    ];
     for (NSString *key in invalidKeys) {
         XCTAssertThrows(object[key] = @"test object");
     }
+    XCTAssertThrows(object[@"ACL"] = @"String");
+    object[@"ACL"] = [AVACL ACL];
+    object[@"ACL"] = nil;
 }
 
 - (void)testRelationForKey {


### PR DESCRIPTION
移除 ACL 这个保留的 key，转而检查 ACL 的类型，与 JavaScript / Python SDK 的行为保持一致。另外更新了相应的单元测试。 @leancloud/ios-group 