### PR TITLE
Fix JSON serialization error for save option

### DIFF
--- a/AVOS/AVOSCloud/Object/AVSaveOption.m
+++ b/AVOS/AVOSCloud/Object/AVSaveOption.m
@@ -19,10 +19,8 @@
     if (self.fetchWhenSave)
         result[@"fetchWhenSave"] = @(YES);
 
-    NSDictionary *where = [self.query.where copy];
-
-    if (where)
-        result[@"where"] = where;
+    if (self.query)
+        result[@"where"] = [self.query whereJSONDictionary];
 
     return result;
 }

--- a/AVOS/AVOSCloud/Query/AVQuery.m
+++ b/AVOS/AVOSCloud/Query/AVQuery.m
@@ -1091,6 +1091,12 @@ NSString *LCStringFromDistanceUnit(AVQueryDistanceUnit unit) {
     return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 }
 
+- (NSDictionary *)whereJSONDictionary {
+    NSData *data = [[self whereString] dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *dictionary = [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+    return dictionary;
+}
+
 #pragma mark - Util methods
 - (void)raiseSyncExceptionIfNeed {
     if (self.cachePolicy == kAVCachePolicyCacheThenNetwork) {

--- a/AVOS/AVOSCloud/Query/AVQuery_Internal.h
+++ b/AVOS/AVOSCloud/Query/AVQuery_Internal.h
@@ -38,4 +38,9 @@
  */
 - (void)processEnd:(BOOL)end;
 
+/**
+ * Get JSON-compatible dictionary of where constraints.
+ */
+- (NSDictionary *)whereJSONDictionary;
+
 @end

--- a/AVOS/AVOSCloudTests/LogicTests/AVObjectTest.m
+++ b/AVOS/AVOSCloudTests/LogicTests/AVObjectTest.m
@@ -986,6 +986,27 @@ const void *AVObjectTestDeleteAll = &AVObjectTestDeleteAll;
     [self addDeleteObject:objectB];
 }
 
+- (void)testSaveOption {
+    AVObject *object = [[AVObject alloc] init];
+    NSError *error = nil;
+    [object save:&error];
+
+    XCTAssertNil(error, @"%@", error.localizedDescription);
+
+    object[@"foo"] = @"bar";
+
+    AVSaveOption *option = [[AVSaveOption alloc] init];
+    AVQuery *query = [[AVQuery alloc] init];
+
+    [query whereKey:@"createdAt" lessThan:object.createdAt];
+    option.query = query;
+
+    [object saveWithOption:option error:&error];
+
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.code, 305);
+}
+
 - (void)testSetTwoTimesForOneKey {
     AVObject *obj = [AVObject objectWithClassName:self.className];
     [obj addObject:@"swimming" forKey:@"array"];


### PR DESCRIPTION
修复当 AVSaveOption 的 query 中包含非 JSON 兼容的查询条件（例如 NSDate 对象）时，JSON 序列化失败的问题。关联 issue #88。 @leancloud/ios-group 