### PR TITLE
Avoid crash when make nil equality testing for query

### DIFF
--- a/AVOS/AVOSCloud/Query/AVQuery.m
+++ b/AVOS/AVOSCloud/Query/AVQuery.m
@@ -234,14 +234,20 @@ NSString *LCStringFromDistanceUnit(AVQueryDistanceUnit unit) {
     [self addWhereItem:dict forKey:key];
 }
 
+- (id)valueForEqualityTesting:(id)object {
+    if (!object) {
+        return [NSNull null];
+    } else if ([object isKindOfClass:[AVObject class]]) {
+        return [AVObjectUtils dictionaryFromAVObjectPointer:(AVObject *)object];
+    } else {
+        return object;
+    }
+}
+
 - (void)whereKey:(NSString *)key equalTo:(id)object
 {
-    if ([object isKindOfClass:[AVObject class]]) {
-        [self addWhereItem:@{@"$eq":[AVObjectUtils dictionaryFromAVObjectPointer:(AVObject *)object]}
-                    forKey:key];
-    } else {
-        [self addWhereItem:@{@"$eq":object} forKey:key];
-    }
+    NSDictionary * dict = @{@"$eq": [self valueForEqualityTesting:object]};
+    [self addWhereItem:dict forKey:key];
 }
 
 - (void)whereKey:(NSString *)key sizeEqualTo:(NSUInteger)count
@@ -276,7 +282,7 @@ NSString *LCStringFromDistanceUnit(AVQueryDistanceUnit unit) {
 
 - (void)whereKey:(NSString *)key notEqualTo:(id)object
 {
-    NSDictionary * dict = @{@"$ne": object};
+    NSDictionary * dict = @{@"$ne": [self valueForEqualityTesting:object]};
     [self addWhereItem:dict forKey:key];
 }
 


### PR DESCRIPTION
修复 AVQuery 在做 nil 的相等性测试时，SDK 崩溃的问题。这个改动将 nil 转换成 NSNull。

关联工单： https://leanticket.cn/t/leancloud/3276 @leancloud/ios-group 