### PR TITLE
add withLastMessage and compact options to conversation query

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -997,12 +997,11 @@ static BOOL AVIMClientHasInstantiated = NO;
     [self fetchConversationIfNeeded:conversation withBlock:^(AVIMConversation *conversation) {
         /* Update lastMessageAt if needed. */
         NSDate *messageSentAt = [NSDate dateWithTimeIntervalSince1970:(message.sendTimestamp / 1000.0)];
-
-        if (!conversation.lastMessageAt || [conversation.lastMessageAt compare:messageSentAt] == NSOrderedAscending) {
-            conversation.lastMessageAt = messageSentAt;
-        }
         if (!message.transient) {
-            conversation.lastMessageInCache = message;
+            if (!conversation.lastMessageAt || [conversation.lastMessageAt compare:messageSentAt] == NSOrderedAscending) {
+                conversation.lastMessageAt = messageSentAt;
+            }
+            conversation.lastMessage = message;
         }
         [ws passMessage:message toConversation:conversation];
     }];

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -1001,7 +1001,9 @@ static BOOL AVIMClientHasInstantiated = NO;
         if (!conversation.lastMessageAt || [conversation.lastMessageAt compare:messageSentAt] == NSOrderedAscending) {
             conversation.lastMessageAt = messageSentAt;
         }
-        conversation.lastMessageInCache = message;
+        if (!message.transient) {
+            conversation.lastMessageInCache = message;
+        }
         [ws passMessage:message toConversation:conversation];
     }];
 }

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -1001,7 +1001,7 @@ static BOOL AVIMClientHasInstantiated = NO;
         if (!conversation.lastMessageAt || [conversation.lastMessageAt compare:messageSentAt] == NSOrderedAscending) {
             conversation.lastMessageAt = messageSentAt;
         }
-
+        conversation.lastMessageInCache = message;
         [ws passMessage:message toConversation:conversation];
     }];
 }

--- a/AVOS/AVOSCloudIM/AVIMConversation.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation.h
@@ -58,6 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  The last message in this conversation.
+ *  @attention Getter method may query lastMessage from SQL, this may take a long time, be careful to use getter method in main thread.
  */
 @property (nonatomic, strong, readonly, nullable) AVIMMessage  *lastMessage;
 

--- a/AVOS/AVOSCloudIM/AVIMConversation.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation.h
@@ -57,6 +57,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly, nullable) NSDate       *updateAt;
 
 /**
+ *  The last message in this conversation.
+ */
+@property (nonatomic, strong, readonly, nullable) AVIMMessage  *lastMessage;
+
+/**
  *  The send timestamp of the last message in this conversation.
  */
 @property (nonatomic, strong, readonly, nullable) NSDate       *lastMessageAt;

--- a/AVOS/AVOSCloudIM/AVIMConversation.m
+++ b/AVOS/AVOSCloudIM/AVIMConversation.m
@@ -998,6 +998,7 @@
     keyedConversation.createAt       = self.createAt;
     keyedConversation.updateAt       = self.updateAt;
     keyedConversation.lastMessageAt  = self.lastMessageAt;
+    keyedConversation.lastMessage    = self.lastMessage;
     keyedConversation.name           = self.name;
     keyedConversation.members        = self.members;
     keyedConversation.attributes     = self.attributes;
@@ -1013,6 +1014,7 @@
     self.createAt          = keyedConversation.createAt;
     self.updateAt          = keyedConversation.updateAt;
     self.lastMessageAt     = keyedConversation.lastMessageAt;
+    self.lastMessage       = keyedConversation.lastMessage;
     self.name              = keyedConversation.name;
     self.members           = keyedConversation.members;
     self.attributes        = keyedConversation.attributes;

--- a/AVOS/AVOSCloudIM/AVIMConversationQuery.h
+++ b/AVOS/AVOSCloudIM/AVIMConversationQuery.h
@@ -20,10 +20,10 @@ extern NSString *const kAVIMKeyMember;
 extern NSString *const kAVIMKeyCreator;
 extern NSString *const kAVIMKeyConversationId;
 
-typedef NS_ENUM(NSInteger, AVIMConversationOption) {
-    AVIMConversationOptionNone = 0,
-    AVIMConversationOptionCompact = 1 << 0, /**< 不返回成员列表 */
-    AVIMConversationOptionWithMessage = 1 << 0, /**< 返回对话最近一条消息 */
+typedef NS_OPTIONS(uint64_t, AVIMConversationQueryOption) {
+    AVIMConversationQueryOptionNone = 0,
+    AVIMConversationQueryOptionCompact = 1 << 0, /**< 不返回成员列表 */
+    AVIMConversationQueryOptionWithMessage = 1 << 1, /**< 返回对话最近一条消息 */
 };
 
 @interface AVIMConversationQuery : NSObject
@@ -51,7 +51,7 @@ typedef NS_ENUM(NSInteger, AVIMConversationOption) {
 /*!
  * 查询条件
  */
-@property (nonatomic, assign) AVIMConversationOption option;
+@property (nonatomic, assign) AVIMConversationQueryOption option;
 
 /*!
  * Build an query that is the OR of the passed in queries.

--- a/AVOS/AVOSCloudIM/AVIMConversationQuery.h
+++ b/AVOS/AVOSCloudIM/AVIMConversationQuery.h
@@ -50,6 +50,7 @@ typedef NS_OPTIONS(uint64_t, AVIMConversationQueryOption) {
 
 /*!
  * 查询条件
+ * @attention 如果设置了除 AVIMConversationQueryOptionNone 之外的选项，本次查询的缓存策略将会被修改为kAVIMCachePolicyNetworkOnly
  */
 @property (nonatomic, assign) AVIMConversationQueryOption option;
 

--- a/AVOS/AVOSCloudIM/AVIMConversationQuery.h
+++ b/AVOS/AVOSCloudIM/AVIMConversationQuery.h
@@ -20,6 +20,12 @@ extern NSString *const kAVIMKeyMember;
 extern NSString *const kAVIMKeyCreator;
 extern NSString *const kAVIMKeyConversationId;
 
+typedef NS_ENUM(NSInteger, AVIMConversationOption) {
+    AVIMConversationOptionNone = 0,
+    AVIMConversationOptionCompact = 1 << 0, /**< 不返回成员列表 */
+    AVIMConversationOptionWithMessage = 1 << 0, /**< 返回对话最近一条消息 */
+};
+
 @interface AVIMConversationQuery : NSObject
 
 /*!
@@ -41,6 +47,11 @@ extern NSString *const kAVIMKeyConversationId;
  设置缓存的过期时间，默认是 1 小时（1 * 60 * 60）
  */
 @property (nonatomic, assign) NSTimeInterval cacheMaxAge;
+
+/*!
+ * 查询条件
+ */
+@property (nonatomic, assign) AVIMConversationOption option;
 
 /*!
  * Build an query that is the OR of the passed in queries.

--- a/AVOS/AVOSCloudIM/AVIMConversationQuery.h
+++ b/AVOS/AVOSCloudIM/AVIMConversationQuery.h
@@ -50,7 +50,6 @@ typedef NS_OPTIONS(uint64_t, AVIMConversationQueryOption) {
 
 /*!
  * 查询条件
- * @attention 如果设置了除 AVIMConversationQueryOptionNone 之外的选项，本次查询的缓存策略将会被修改为kAVIMCachePolicyNetworkOnly
  */
 @property (nonatomic, assign) AVIMConversationQueryOption option;
 

--- a/AVOS/AVOSCloudIM/AVIMConversationQuery.m
+++ b/AVOS/AVOSCloudIM/AVIMConversationQuery.m
@@ -412,7 +412,6 @@ NSString *const kAVIMKeyConversationId = @"objectId";
         conversation.members = [dict objectForKey:@"m"];
         conversation.muted = [[dict objectForKey:@"muted"] boolValue];
         conversation.transient = [[dict objectForKey:@"tr"] boolValue];
-
         [conversations addObject:conversation];
     }
 
@@ -522,17 +521,6 @@ NSString *const kAVIMKeyConversationId = @"objectId";
     default:
         break;
     }
-}
-
-#pragma mark -
-#pragma mark - AVIMConversationQueryConditions Method
-
-- (BOOL)isWithLastMessagesRefreshed {
-    return self.conditions.isWithLastMessagesRefreshed;
-}
-
-- (void)setWithLastMessagesRefreshed:(BOOL)withLastMessagesRefreshed {
-    [self.conditions setWithLastMessagesRefreshed:withLastMessagesRefreshed];
 }
 
 @end

--- a/AVOS/AVOSCloudIM/AVIMConversationQuery.m
+++ b/AVOS/AVOSCloudIM/AVIMConversationQuery.m
@@ -18,6 +18,7 @@
 #import "AVIMErrorUtil.h"
 #import "AVObjectUtils.h"
 #import "LCIMConversationCache.h"
+#import "AVIMMessage_Internal.h"
 
 NSString *const kAVIMKeyName = @"name";
 NSString *const kAVIMKeyMember = @"m";
@@ -402,16 +403,21 @@ NSString *const kAVIMKeyConversationId = @"objectId";
         NSDictionary *lastMessageAt = dict[KEY_LAST_MESSAGE_AT];
 
         conversation.imClient = self.client;
-        conversation.conversationId = [dict objectForKey:@"objectId"];
+        NSString *conversationId = [dict objectForKey:@"objectId"];
+        conversation.conversationId = conversationId;
         conversation.name = [dict objectForKey:KEY_NAME];
         conversation.attributes = [dict objectForKey:KEY_ATTR];
         conversation.creator = [dict objectForKey:@"c"];
         if (createdAt) conversation.createAt = [AVObjectUtils dateFromString:createdAt];
         if (updatedAt) conversation.updateAt = [AVObjectUtils dateFromString:updatedAt];
-        if (lastMessageAt) conversation.lastMessageAt = [AVObjectUtils dateFromDictionary:lastMessageAt];
+        if (lastMessageAt) {
+            conversation.lastMessageAt = [AVObjectUtils dateFromDictionary:lastMessageAt];
+            conversation.lastMessage = [AVIMMessage parseMessageWithConversationId:conversationId result:dict];
+        }
         conversation.members = [dict objectForKey:@"m"];
         conversation.muted = [[dict objectForKey:@"muted"] boolValue];
         conversation.transient = [[dict objectForKey:@"tr"] boolValue];
+
         [conversations addObject:conversation];
     }
 

--- a/AVOS/AVOSCloudIM/AVIMConversationQuery.m
+++ b/AVOS/AVOSCloudIM/AVIMConversationQuery.m
@@ -348,7 +348,7 @@ NSString *const kAVIMKeyConversationId = @"objectId";
     jsonObjectMessage.data_p = [self whereString];
     command.where = jsonObjectMessage;
     command.sort = self.order;
-
+    
     if (self.skip > 0) {
         command.skip = (uint32_t)self.skip;
     }
@@ -358,6 +358,11 @@ NSString *const kAVIMKeyConversationId = @"objectId";
     } else {
         command.limit = 10;
     }
+    
+    if (self.option) {
+        command.flag = self.option;
+    }
+    
     [genericCommand avim_addRequiredKeyWithCommand:command];
     return genericCommand;
 }
@@ -394,7 +399,7 @@ NSString *const kAVIMKeyConversationId = @"objectId";
 
         NSString *createdAt = dict[@"createdAt"];
         NSString *updatedAt = dict[@"updatedAt"];
-        NSDictionary *lastMessageAt = dict[@"lm"];
+        NSDictionary *lastMessageAt = dict[KEY_LAST_MESSAGE_AT];
 
         conversation.imClient = self.client;
         conversation.conversationId = [dict objectForKey:@"objectId"];
@@ -517,6 +522,17 @@ NSString *const kAVIMKeyConversationId = @"objectId";
     default:
         break;
     }
+}
+
+#pragma mark -
+#pragma mark - AVIMConversationQueryConditions Method
+
+- (BOOL)isWithLastMessagesRefreshed {
+    return self.conditions.isWithLastMessagesRefreshed;
+}
+
+- (void)setWithLastMessagesRefreshed:(BOOL)withLastMessagesRefreshed {
+    [self.conditions setWithLastMessagesRefreshed:withLastMessagesRefreshed];
 }
 
 @end

--- a/AVOS/AVOSCloudIM/AVIMConversationQuery.m
+++ b/AVOS/AVOSCloudIM/AVIMConversationQuery.m
@@ -359,7 +359,6 @@ NSString *const kAVIMKeyConversationId = @"objectId";
         command.limit = 10;
     }
     
-    
     [genericCommand avim_addRequiredKeyWithCommand:command];
     return genericCommand;
 }
@@ -378,8 +377,7 @@ NSString *const kAVIMKeyConversationId = @"objectId";
     });
 }
 
-- (id)JSONValue:(NSString *)string
-{
+- (id)JSONValue:(NSString *)string {
     NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
     NSError *error = nil;
     id result = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&error];

--- a/AVOS/AVOSCloudIM/AVIMConversationQuery.m
+++ b/AVOS/AVOSCloudIM/AVIMConversationQuery.m
@@ -27,6 +27,13 @@ NSString *const kAVIMKeyConversationId = @"objectId";
 
 @implementation AVIMConversationQuery
 
+- (void)setOption:(AVIMConversationQueryOption)option {
+    _option = option;
+    if (option != AVIMConversationQueryOptionNone) {
+        self.cachePolicy = kAVIMCachePolicyNetworkOnly;
+    }
+}
+
 +(NSDictionary *)dictionaryFromGeoPoint:(AVGeoPoint *)point
 {
     return @{ @"__type": @"GeoPoint", @"latitude": @(point.latitude), @"longitude": @(point.longitude) };

--- a/AVOS/AVOSCloudIM/AVIMConversationQuery.m
+++ b/AVOS/AVOSCloudIM/AVIMConversationQuery.m
@@ -27,20 +27,11 @@ NSString *const kAVIMKeyConversationId = @"objectId";
 
 @implementation AVIMConversationQuery
 
-- (void)setOption:(AVIMConversationQueryOption)option {
-    _option = option;
-    if (option != AVIMConversationQueryOptionNone) {
-        self.cachePolicy = kAVIMCachePolicyNetworkOnly;
-    }
-}
-
-+(NSDictionary *)dictionaryFromGeoPoint:(AVGeoPoint *)point
-{
++(NSDictionary *)dictionaryFromGeoPoint:(AVGeoPoint *)point {
     return @{ @"__type": @"GeoPoint", @"latitude": @(point.latitude), @"longitude": @(point.longitude) };
 }
 
-+(AVGeoPoint *)geoPointFromDictionary:(NSDictionary *)dict
-{
++(AVGeoPoint *)geoPointFromDictionary:(NSDictionary *)dict {
     AVGeoPoint * point = [[AVGeoPoint alloc]init];
     point.latitude = [[dict objectForKey:@"latitude"] doubleValue];
     point.longitude = [[dict objectForKey:@"longitude"] doubleValue];
@@ -356,7 +347,8 @@ NSString *const kAVIMKeyConversationId = @"objectId";
     jsonObjectMessage.data_p = [self whereString];
     command.where = jsonObjectMessage;
     command.sort = self.order;
-    
+    command.flag = self.option;
+
     if (self.skip > 0) {
         command.skip = (uint32_t)self.skip;
     }
@@ -367,9 +359,6 @@ NSString *const kAVIMKeyConversationId = @"objectId";
         command.limit = 10;
     }
     
-    if (self.option) {
-        command.flag = self.option;
-    }
     
     [genericCommand avim_addRequiredKeyWithCommand:command];
     return genericCommand;

--- a/AVOS/AVOSCloudIM/AVIMConversation_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation_Internal.h
@@ -14,6 +14,7 @@
 #define KEY_DATA @"data"
 #define KEY_FROM @"from"
 #define KEY_MSGID @"msgId"
+#define KEY_LAST_MESSAGE_AT @"lm"
 
 @class AVIMConversationUpdateBuilder;
 

--- a/AVOS/AVOSCloudIM/AVIMConversation_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation_Internal.h
@@ -15,20 +15,25 @@
 #define KEY_FROM @"from"
 #define KEY_MSGID @"msgId"
 #define KEY_LAST_MESSAGE_AT @"lm"
+#define KEY_LAST_MESSAGE @"msg"
+#define KEY_LAST_MESSAGE_FROM @"msg_from"
+#define KEY_LAST_MESSAGE_MID @"msg_mid"
+#define KEY_LAST_MESSAGE_TIMESTAMP @"msg_timestamp"
+
 
 @class AVIMConversationUpdateBuilder;
 
 @interface AVIMConversation ()
 
-@property(nonatomic, copy)   NSString     *name;            // 对话名字
-@property(nonatomic, strong) NSDate       *createAt;        // 创建时间
-@property(nonatomic, strong) NSDate       *updateAt;        // 最后更新时间
-@property(nonatomic, strong) NSDate       *lastMessageAt;   // 对话中最后一条消息的发送时间
-@property(nonatomic, strong) NSDictionary *attributes;      // 自定义属性
-@property(nonatomic, assign) BOOL          muted;           // 静音状态
-@property(nonatomic, assign) BOOL          transient;       // 是否为临时会话（开放群组）
+@property (nonatomic, copy)   NSString     *name;            /**< 对话名字 */
+@property (nonatomic, strong) NSDate       *createAt;        /**< 创建时间 */
+@property (nonatomic, strong) NSDate       *updateAt;        /**< 最后更新时间 */
+@property (nonatomic, strong) NSDate       *lastMessageAt;   /**< 对话中最后一条消息的发送时间 */
+@property (nonatomic, strong) NSDictionary *attributes;      /**< 自定义属性 */
+@property (nonatomic, assign) BOOL          muted;           /**< 静音状态 */
+@property (nonatomic, assign) BOOL          transient;       /**< 是否为临时会话（开放群组） */
+@property (nonatomic, strong) AVIMMessage  *lastMessage;     /**< 对话中最后一条消息 */
 
-//@property(nonatomic, strong)AVIMConversationUpdateBuilder *updateBuilder;
 - (instancetype)initWithConversationId:(NSString *)conversationId;
 - (void)setConversationId:(NSString *)conversationId;
 - (void)setMembers:(NSArray *)members;

--- a/AVOS/AVOSCloudIM/AVIMConversation_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation_Internal.h
@@ -33,7 +33,6 @@
 @property (nonatomic, assign) BOOL          muted;           /**< 静音状态 */
 @property (nonatomic, assign) BOOL          transient;       /**< 是否为临时会话（开放群组） */
 @property (nonatomic, strong) AVIMMessage  *lastMessage;     /**< 对话中最后一条消息 */
-@property (nonatomic, strong) AVIMMessage  *lastMessageInCache;     /**< 消息记录缓存中最后一条消息 */
 
 - (instancetype)initWithConversationId:(NSString *)conversationId;
 - (void)setConversationId:(NSString *)conversationId;

--- a/AVOS/AVOSCloudIM/AVIMConversation_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation_Internal.h
@@ -33,6 +33,7 @@
 @property (nonatomic, assign) BOOL          muted;           /**< 静音状态 */
 @property (nonatomic, assign) BOOL          transient;       /**< 是否为临时会话（开放群组） */
 @property (nonatomic, strong) AVIMMessage  *lastMessage;     /**< 对话中最后一条消息 */
+@property (nonatomic, strong) AVIMMessage  *lastMessageInCache;     /**< 消息记录缓存中最后一条消息 */
 
 - (instancetype)initWithConversationId:(NSString *)conversationId;
 - (void)setConversationId:(NSString *)conversationId;

--- a/AVOS/AVOSCloudIM/AVIMKeyedConversation.h
+++ b/AVOS/AVOSCloudIM/AVIMKeyedConversation.h
@@ -10,6 +10,7 @@
 
 @class AVIMClient;
 @class AVIMConversation;
+@class AVIMMessage;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -23,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly, nullable) NSDate       *createAt;       // 创建时间
 @property (nonatomic, strong, readonly, nullable) NSDate       *updateAt;       // 最后更新时间
 @property (nonatomic, strong, readonly, nullable) NSDate       *lastMessageAt;  // 对话中最后一条消息的发送时间
+@property (nonatomic, strong, readonly, nullable) AVIMMessage  *lastMessage;  // 对话中最后一条消息的发送时间
 @property (nonatomic, copy,   readonly, nullable) NSString     *name;           // 对话名字
 @property (nonatomic, strong, readonly, nullable) NSArray      *members;        // 对话参与者列表
 @property (nonatomic, strong, readonly, nullable) NSDictionary *attributes;     // 自定义属性

--- a/AVOS/AVOSCloudIM/AVIMKeyedConversation.m
+++ b/AVOS/AVOSCloudIM/AVIMKeyedConversation.m
@@ -26,6 +26,7 @@
         self.createAt       = [aDecoder decodeObjectForKey:LC_SEL_STR(createAt)];
         self.updateAt       = [aDecoder decodeObjectForKey:LC_SEL_STR(updateAt)];
         self.lastMessageAt  = [aDecoder decodeObjectForKey:LC_SEL_STR(lastMessageAt)];
+        self.lastMessage    = [aDecoder decodeObjectForKey:LC_SEL_STR(lastMessage)];
         self.name           = [aDecoder decodeObjectForKey:LC_SEL_STR(name)];
         self.members        = [aDecoder decodeObjectForKey:LC_SEL_STR(members)];
         self.attributes     = [aDecoder decodeObjectForKey:LC_SEL_STR(attributes)];
@@ -43,6 +44,7 @@
     [aCoder encodeObject:self.createAt       forKey:LC_SEL_STR(createAt)];
     [aCoder encodeObject:self.updateAt       forKey:LC_SEL_STR(updateAt)];
     [aCoder encodeObject:self.lastMessageAt  forKey:LC_SEL_STR(lastMessageAt)];
+    [aCoder encodeObject:self.lastMessage    forKey:LC_SEL_STR(lastMessage)];
     [aCoder encodeObject:self.name           forKey:LC_SEL_STR(name)];
     [aCoder encodeObject:self.members        forKey:LC_SEL_STR(members)];
     [aCoder encodeObject:self.attributes     forKey:LC_SEL_STR(attributes)];

--- a/AVOS/AVOSCloudIM/AVIMKeyedConversation_internal.h
+++ b/AVOS/AVOSCloudIM/AVIMKeyedConversation_internal.h
@@ -7,6 +7,7 @@
 //
 
 #import "AVIMKeyedConversation.h"
+@class AVIMMessage;
 
 @interface AVIMKeyedConversation ()
 
@@ -16,6 +17,7 @@
 @property (nonatomic, strong) NSDate       *createAt;
 @property (nonatomic, strong) NSDate       *updateAt;
 @property (nonatomic, strong) NSDate       *lastMessageAt;
+@property (nonatomic, strong) AVIMMessage  *lastMessage;
 @property (nonatomic, copy)   NSString     *name;
 @property (nonatomic, strong) NSArray      *members;
 @property (nonatomic, strong) NSDictionary *attributes;

--- a/AVOS/AVOSCloudIM/AVIMMessage.m
+++ b/AVOS/AVOSCloudIM/AVIMMessage.m
@@ -10,6 +10,9 @@
 #import "AVMPMessagePack.h"
 #import "AVIMMessageObject.h"
 #import "AVIMMessage_Internal.h"
+#import "AVIMConversation_Internal.h"
+#import "AVIMTypedMessage_Internal.h"
+
 /*
  {
  "cmd": "direct",
@@ -105,6 +108,38 @@
     } else {
         return AVIMMessageIOTypeIn;
     }
+}
+
+/*!
+ * 
+ "msg":"{"_lctype":-1,"_lctext":"1620318941"}",
+ "msg_from":"a"
+ "msg_mid":"2USGXPmbTEWjt9WnNRZpWQ",
+ "msg_timestamp":1480325615220,
+ */
++ (instancetype)parseMessageWithConversationId:(NSString *)conversationId result:(NSDictionary *)result {
+    id messageContent = result[KEY_LAST_MESSAGE];
+    if((!messageContent) || (messageContent == [NSNull null])) { return nil; }
+    
+    NSString *from = result[KEY_LAST_MESSAGE_FROM];
+    NSString *content = (NSString *)messageContent;
+    NSTimeInterval timestamp = [result[KEY_LAST_MESSAGE_TIMESTAMP] doubleValue];
+    NSString *messageId = result[KEY_LAST_MESSAGE_MID];
+    
+    AVIMMessage *message = nil;
+    AVIMTypedMessageObject *messageObject = [[AVIMTypedMessageObject alloc] initWithJSON:content];
+    if ([messageObject isValidTypedMessageObject]) {
+        message = [AVIMTypedMessage messageWithMessageObject:messageObject];
+    } else {
+        message = [[AVIMMessage alloc] init];
+    }
+    message.content = content;
+    message.sendTimestamp = timestamp;
+    message.conversationId = conversationId;
+    message.clientId = from;
+    message.messageId = messageId;
+    message.status = AVIMMessageStatusDelivered;
+    return message;
 }
 
 @end

--- a/AVOS/AVOSCloudIM/AVIMMessage_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMMessage_Internal.h
@@ -40,6 +40,8 @@
  */
 - (NSString *)payload;
 
++ (instancetype)parseMessageWithConversationId:(NSString *)conversationId result:(NSDictionary *)result;
+
 //======================================================================
 //====== override readonly property to readwrite for internal use ======
 //======================================================================

--- a/AVOS/AVOSCloudIM/Commands/AVIMConversationOutCommand.h
+++ b/AVOS/AVOSCloudIM/Commands/AVIMConversationOutCommand.h
@@ -9,6 +9,7 @@
 #import "AVIMSignature.h"
 #import "AVIMDynamicObject.h"
 #import "AVIMCommandCommon.h"
+#import "AVIMConversationQuery.h"
 
 @interface AVIMConversationOutCommand : AVIMDynamicObject
 
@@ -34,5 +35,6 @@
 @property (nonatomic, assign) uint32_t       skip;
 @property (nonatomic, assign) uint32_t       limit;
 @property (nonatomic, assign) BOOL           unique;
+@property (nonatomic, assign) AVIMConversationQueryOption option;
 
 @end

--- a/AVOS/AVOSCloudIM/Commands/AVIMConversationOutCommand.m
+++ b/AVOS/AVOSCloudIM/Commands/AVIMConversationOutCommand.m
@@ -19,7 +19,7 @@
 
 @implementation AVIMConversationOutCommand
 
-@dynamic i, cmd, code, appCode, reason, peerId, needResponse, callback, op, cid, m, transient, muted, s, t, n, signature, attr, where, sort, skip, limit, unique;
+@dynamic i, cmd, code, appCode, reason, peerId, needResponse, callback, op, cid, m, transient, muted, s, t, n, signature, attr, where, sort, skip, limit, unique, option;
 
 - (void)setSignature:(AVIMSignature *)signature {
     _signature = signature;

--- a/AVOS/AVOSCloudIM/Commands/AVIMGenericCommand+AVIMMessagesAdditions.m
+++ b/AVOS/AVOSCloudIM/Commands/AVIMGenericCommand+AVIMMessagesAdditions.m
@@ -447,6 +447,7 @@ static uint16_t _searial_id = 0;
     NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:NULL];
     [command setObject:[NSMutableDictionary dictionaryWithDictionary:json] forKey:@"where"];
     [command setObject:self.convMessage.sort forKey:@"sort"];
+    [command setObject:@(self.convMessage.flag) forKey:@"option"];
     
     if (self.convMessage.hasSkip) {
         [command setObject:@(self.convMessage.skip) forKey:@"skip"];

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMConversationCacheStore.m
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMConversationCacheStore.m
@@ -47,6 +47,7 @@
         [NSNumber numberWithDouble:[conversation.createAt timeIntervalSince1970]],
         [NSNumber numberWithDouble:[conversation.updateAt timeIntervalSince1970]],
         [NSNumber numberWithDouble:[conversation.lastMessageAt timeIntervalSince1970]],
+        conversation.lastMessage ? [NSKeyedArchiver archivedDataWithRootObject:conversation.lastMessage] : [NSNull null],
         [NSNumber numberWithInteger:conversation.muted],
         [NSNumber numberWithDouble:expireAt]
     ];
@@ -154,8 +155,11 @@
     conversation.createAt       = [self dateFromTimeInterval:[result doubleForColumn:LCIM_FIELD_CREATE_AT]];
     conversation.updateAt       = [self dateFromTimeInterval:[result doubleForColumn:LCIM_FIELD_UPDATE_AT]];
     conversation.lastMessageAt  = [self dateFromTimeInterval:[result doubleForColumn:LCIM_FIELD_LAST_MESSAGE_AT]];
+    conversation.lastMessage    = ({
+        NSData *data = [result dataForColumn:LCIM_FIELD_LAST_MESSAGE];
+        data ? [NSKeyedUnarchiver unarchiveObjectWithData:data] : nil;
+    });
     conversation.muted          = [result boolForColumn:LCIM_FIELD_MUTED];
-
     return conversation;
 }
 

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMConversationCacheStore.m
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMConversationCacheStore.m
@@ -32,7 +32,13 @@
         /* Version 1: Add muted column. */
         [LCDatabaseMigration migrationWithBlock:^(LCDatabase *db) {
             [db executeUpdate:@"ALTER TABLE conversation ADD COLUMN muted INTEGER"];
+        }],
+        
+        /* Version 2: Add lastMessage column. */
+        [LCDatabaseMigration migrationWithBlock:^(LCDatabase *db) {
+            [db executeUpdate:@"ALTER TABLE conversation ADD COLUMN last_message BLOB"];
         }]
+        
     ]];
 }
 

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMConversationCacheStore.m
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMConversationCacheStore.m
@@ -67,15 +67,11 @@
     NSTimeInterval expireAt = [[NSDate date] timeIntervalSince1970] + maxAge;
     for (AVIMConversation *conversation in conversations) {
         if (!conversation.conversationId) continue;
-        BOOL noMembers = !conversation.members.count || conversation.members.count == 0;
-        BOOL noLastMessage = !conversation.lastMessage;
-        if (noMembers || noLastMessage) {
+        BOOL noMembers = (!conversation.members || conversation.members.count == 0);
+        if (noMembers) {
             AVIMConversation *conversationInCache = [self conversationForId:conversation.conversationId];
             if (noMembers) {
                 conversation.members = conversationInCache.members;
-            }
-            if (noLastMessage) {
-                conversation.lastMessage = conversationInCache.lastMessage;
             }
         }
         NSArray *insertionRecord = [self insertionRecordForConversation:conversation expireAt:expireAt];

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMConversationCacheStoreSQL.h
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMConversationCacheStoreSQL.h
@@ -9,11 +9,7 @@
 #ifndef AVOS_LCIMConversationCacheStoreSQL_h
 #define AVOS_LCIMConversationCacheStoreSQL_h
 
-/*!
- * 3.7.3版本后，conversation缓存多了lastMessage字段
- */
-#define LCIM_TABLE_CONVERSATION_VERSION @"V1.0"
-#define LCIM_TABLE_CONVERSATION         @"conversation" @"-" LCIM_TABLE_CONVERSATION_VERSION
+#define LCIM_TABLE_CONVERSATION         @"conversation"
 
 #define LCIM_FIELD_CONVERSATION_ID      @"conversation_id"
 #define LCIM_FIELD_NAME                 @"name"
@@ -39,7 +35,6 @@
         LCIM_FIELD_CREATE_AT            @" REAL, "                \
         LCIM_FIELD_UPDATE_AT            @" REAL, "                \
         LCIM_FIELD_LAST_MESSAGE_AT      @" REAL, "                \
-        LCIM_FIELD_LAST_MESSAGE         @" BLOB, "                \
         LCIM_FIELD_EXPIRE_AT            @" REAL, "                \
         @"PRIMARY KEY(" LCIM_FIELD_CONVERSATION_ID @")"           \
     @")"
@@ -55,10 +50,10 @@
         LCIM_FIELD_CREATE_AT            @", "                  \
         LCIM_FIELD_UPDATE_AT            @", "                  \
         LCIM_FIELD_LAST_MESSAGE_AT      @", "                  \
-        LCIM_FIELD_LAST_MESSAGE         @", "                  \
+        LCIM_FIELD_LAST_MESSAGE         @", " /* Version 2 */  \
         LCIM_FIELD_MUTED                @", " /* Version 1 */  \
         LCIM_FIELD_EXPIRE_AT                                   \
-    @") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    @") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 
 #define LCIM_SQL_DELETE_CONVERSATION              \
     @"DELETE FROM " LCIM_TABLE_CONVERSATION @" "  \

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMConversationCacheStoreSQL.h
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMConversationCacheStoreSQL.h
@@ -9,7 +9,11 @@
 #ifndef AVOS_LCIMConversationCacheStoreSQL_h
 #define AVOS_LCIMConversationCacheStoreSQL_h
 
-#define LCIM_TABLE_CONVERSATION         @"conversation"
+/*!
+ * 3.7.3版本后，conversation缓存多了lastMessage字段
+ */
+#define LCIM_TABLE_CONVERSATION_VERSION @"V1.0"
+#define LCIM_TABLE_CONVERSATION         @"conversation" @"-" LCIM_TABLE_CONVERSATION_VERSION
 
 #define LCIM_FIELD_CONVERSATION_ID      @"conversation_id"
 #define LCIM_FIELD_NAME                 @"name"
@@ -20,6 +24,7 @@
 #define LCIM_FIELD_CREATE_AT            @"create_at"
 #define LCIM_FIELD_UPDATE_AT            @"update_at"
 #define LCIM_FIELD_LAST_MESSAGE_AT      @"last_message_at"
+#define LCIM_FIELD_LAST_MESSAGE         @"last_message"
 #define LCIM_FIELD_MUTED                @"muted"
 #define LCIM_FIELD_EXPIRE_AT            @"expire_at"
 
@@ -34,6 +39,7 @@
         LCIM_FIELD_CREATE_AT            @" REAL, "                \
         LCIM_FIELD_UPDATE_AT            @" REAL, "                \
         LCIM_FIELD_LAST_MESSAGE_AT      @" REAL, "                \
+        LCIM_FIELD_LAST_MESSAGE         @" BLOB, "                \
         LCIM_FIELD_EXPIRE_AT            @" REAL, "                \
         @"PRIMARY KEY(" LCIM_FIELD_CONVERSATION_ID @")"           \
     @")"
@@ -49,6 +55,7 @@
         LCIM_FIELD_CREATE_AT            @", "                  \
         LCIM_FIELD_UPDATE_AT            @", "                  \
         LCIM_FIELD_LAST_MESSAGE_AT      @", "                  \
+        LCIM_FIELD_LAST_MESSAGE         @", "                  \
         LCIM_FIELD_MUTED                @", " /* Version 1 */  \
         LCIM_FIELD_EXPIRE_AT                                   \
     @") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"

--- a/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
+++ b/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
@@ -59,9 +59,11 @@
         }];
     }];
     WAIT;
-    AVIMConversationQuery *query = [[AVIMClient defaultClient] conversationQuery];
-    query.option = AVIMConversationQueryOptionWithMessage;
-    [query getConversationById:convid callback:^(AVIMConversation *conversation, NSError *error) {
+    
+    AVIMConversationQuery *query0 = [[AVIMClient defaultClient] conversationQuery];
+    query0.cachePolicy = kAVIMCachePolicyCacheElseNetwork;
+    query0.option = AVIMConversationQueryOptionWithMessage;
+    [query0 getConversationById:convid callback:^(AVIMConversation *conversation, NSError *error) {
         XCTAssertNil(error);
         XCTAssertEqualObjects(conversation.name, name);
         XCTAssertEqual(conversation.members.count, 2);
@@ -79,6 +81,51 @@
         NOTIFY;
     }];
     WAIT;
+    
+    AVIMConversationQuery *query1 = [[AVIMClient defaultClient] conversationQuery];
+    query1.cachePolicy = kAVIMCachePolicyCacheElseNetwork;
+    query1.option = AVIMConversationQueryOptionNone;
+    [query1 getConversationById:convid callback:^(AVIMConversation *conversation, NSError *error) {
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(conversation.name, name);
+        XCTAssertEqual(conversation.members.count, 2);
+        XCTAssertTrue([conversation.members containsObject:AVIM_TEST_ClinetID]);
+        XCTAssertTrue([conversation.members containsObject:AVIM_TEST_ClinetID_Peer]);
+        XCTAssertEqual([conversation.attributes[@"type"] intValue], 0);
+        XCTAssertEqualObjects(conversation.creator, AVIM_TEST_ClinetID);
+        XCTAssertNotNil(conversation.createAt);
+        XCTAssertNotNil(conversation.conversationId);
+        XCTAssertFalse(conversation.muted);
+        XCTAssertFalse(conversation.transient);
+        AVIMTypedMessage *typedMessage = (AVIMTypedMessage *)conversation.lastMessage;
+        XCTAssertTrue([typedMessage.text isEqualToString:lastMessageText]);
+        XCTAssertEqual(typedMessage.mediaType, -1);
+        NOTIFY;
+    }];
+    WAIT;
+    
+    AVIMConversationQuery *query2 = [[AVIMClient defaultClient] conversationQuery];
+    query2.cachePolicy = kAVIMCachePolicyCacheElseNetwork;
+    query2.option = AVIMConversationQueryOptionWithMessage;
+    [query2 getConversationById:convid callback:^(AVIMConversation *conversation, NSError *error) {
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(conversation.name, name);
+        XCTAssertEqual(conversation.members.count, 2);
+        XCTAssertTrue([conversation.members containsObject:AVIM_TEST_ClinetID]);
+        XCTAssertTrue([conversation.members containsObject:AVIM_TEST_ClinetID_Peer]);
+        XCTAssertEqual([conversation.attributes[@"type"] intValue], 0);
+        XCTAssertEqualObjects(conversation.creator, AVIM_TEST_ClinetID);
+        XCTAssertNotNil(conversation.createAt);
+        XCTAssertNotNil(conversation.conversationId);
+        XCTAssertFalse(conversation.muted);
+        XCTAssertFalse(conversation.transient);
+        AVIMTypedMessage *typedMessage = (AVIMTypedMessage *)conversation.lastMessage;
+        XCTAssertTrue([typedMessage.text isEqualToString:lastMessageText]);
+        XCTAssertEqual(typedMessage.mediaType, -1);
+        NOTIFY;
+    }];
+    WAIT;
+
 }
 
 //FIXME:TEST FAILED ==> ALL XCTAssertNil FAILED

--- a/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
+++ b/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
@@ -60,30 +60,8 @@
     }];
     WAIT;
     
-    AVIMConversationQuery *query0 = [[AVIMClient defaultClient] conversationQuery];
-    query0.cachePolicy = kAVIMCachePolicyCacheElseNetwork;
-    query0.option = AVIMConversationQueryOptionWithMessage;
-    [query0 getConversationById:convid callback:^(AVIMConversation *conversation, NSError *error) {
-        XCTAssertNil(error);
-        XCTAssertEqualObjects(conversation.name, name);
-        XCTAssertEqual(conversation.members.count, 2);
-        XCTAssertTrue([conversation.members containsObject:AVIM_TEST_ClinetID]);
-        XCTAssertTrue([conversation.members containsObject:AVIM_TEST_ClinetID_Peer]);
-        XCTAssertEqual([conversation.attributes[@"type"] intValue], 0);
-        XCTAssertEqualObjects(conversation.creator, AVIM_TEST_ClinetID);
-        XCTAssertNotNil(conversation.createAt);
-        XCTAssertNotNil(conversation.conversationId);
-        XCTAssertFalse(conversation.muted);
-        XCTAssertFalse(conversation.transient);
-        AVIMTypedMessage *typedMessage = (AVIMTypedMessage *)conversation.lastMessage;
-        XCTAssertTrue([typedMessage.text isEqualToString:lastMessageText]);
-        XCTAssertEqual(typedMessage.mediaType, -1);
-        NOTIFY;
-    }];
-    WAIT;
-    
     AVIMConversationQuery *query1 = [[AVIMClient defaultClient] conversationQuery];
-    query1.cachePolicy = kAVIMCachePolicyCacheElseNetwork;
+    query1.cachePolicy = kAVIMCachePolicyNetworkOnly;
     query1.option = AVIMConversationQueryOptionNone;
     [query1 getConversationById:convid callback:^(AVIMConversation *conversation, NSError *error) {
         XCTAssertNil(error);
@@ -98,14 +76,12 @@
         XCTAssertFalse(conversation.muted);
         XCTAssertFalse(conversation.transient);
         AVIMTypedMessage *typedMessage = (AVIMTypedMessage *)conversation.lastMessage;
-        XCTAssertTrue([typedMessage.text isEqualToString:lastMessageText]);
-        XCTAssertEqual(typedMessage.mediaType, -1);
+        XCTAssertNil(typedMessage);
         NOTIFY;
     }];
     WAIT;
     
     AVIMConversationQuery *query2 = [[AVIMClient defaultClient] conversationQuery];
-    query2.cachePolicy = kAVIMCachePolicyCacheElseNetwork;
     query2.option = AVIMConversationQueryOptionWithMessage;
     [query2 getConversationById:convid callback:^(AVIMConversation *conversation, NSError *error) {
         XCTAssertNil(error);
@@ -120,6 +96,7 @@
         XCTAssertFalse(conversation.muted);
         XCTAssertFalse(conversation.transient);
         AVIMTypedMessage *typedMessage = (AVIMTypedMessage *)conversation.lastMessage;
+        XCTAssertNotNil(typedMessage);
         XCTAssertTrue([typedMessage.text isEqualToString:lastMessageText]);
         XCTAssertEqual(typedMessage.mediaType, -1);
         NOTIFY;

--- a/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
+++ b/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
@@ -101,7 +101,27 @@
         NOTIFY;
     }];
     WAIT;
-
+    
+    AVIMConversationQuery *query3 = [[AVIMClient defaultClient] conversationQuery];
+    [query3 getConversationById:convid callback:^(AVIMConversation *conversation, NSError *error) {
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(conversation.name, name);
+        XCTAssertEqual(conversation.members.count, 2);
+        XCTAssertTrue([conversation.members containsObject:AVIM_TEST_ClinetID]);
+        XCTAssertTrue([conversation.members containsObject:AVIM_TEST_ClinetID_Peer]);
+        XCTAssertEqual([conversation.attributes[@"type"] intValue], 0);
+        XCTAssertEqualObjects(conversation.creator, AVIM_TEST_ClinetID);
+        XCTAssertNotNil(conversation.createAt);
+        XCTAssertNotNil(conversation.conversationId);
+        XCTAssertFalse(conversation.muted);
+        XCTAssertFalse(conversation.transient);
+        AVIMTypedMessage *typedMessage = (AVIMTypedMessage *)conversation.lastMessage;
+        XCTAssertNotNil(typedMessage);
+        XCTAssertTrue([typedMessage.text isEqualToString:lastMessageText]);
+        XCTAssertEqual(typedMessage.mediaType, -1);
+        NOTIFY;
+    }];
+    WAIT;
 }
 
 //FIXME:TEST FAILED ==> ALL XCTAssertNil FAILED

--- a/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
+++ b/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
@@ -78,7 +78,7 @@
         XCTAssertFalse(conversation.muted);
         XCTAssertFalse(conversation.transient);
         AVIMTypedMessage *typedMessage = (AVIMTypedMessage *)conversation.lastMessage;
-        XCTAssertNil(typedMessage);
+        XCTAssertNotNil(typedMessage);
         NOTIFY;
     }];
     WAIT;

--- a/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
+++ b/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
@@ -82,13 +82,12 @@
     WAIT;
     
     AVIMConversationQuery *query2 = [[AVIMClient defaultClient] conversationQuery];
-    query2.option = AVIMConversationQueryOptionWithMessage;
+    query2.option = AVIMConversationQueryOptionWithMessage | AVIMConversationQueryOptionCompact;
     [query2 getConversationById:convid callback:^(AVIMConversation *conversation, NSError *error) {
         XCTAssertNil(error);
         XCTAssertEqualObjects(conversation.name, name);
-        XCTAssertEqual(conversation.members.count, 2);
-        XCTAssertTrue([conversation.members containsObject:AVIM_TEST_ClinetID]);
-        XCTAssertTrue([conversation.members containsObject:AVIM_TEST_ClinetID_Peer]);
+        XCTAssertNil(conversation.members);
+        XCTAssertEqual(conversation.members.count, 0);
         XCTAssertEqual([conversation.attributes[@"type"] intValue], 0);
         XCTAssertEqualObjects(conversation.creator, AVIM_TEST_ClinetID);
         XCTAssertNotNil(conversation.createAt);


### PR DESCRIPTION
Done

* [x] lastMessage 属性解析
* [x] 缓存兼容
* [x] 将options作为Query的参数，以此来达到缓存兼容的目的
* [x] 添加单元测试
* [x] 总是将conversation与的lastMessage与消息记录里的lastMessage做对比，总返回最新的。