### PR TITLE
add new read status mark to message

### DIFF
--- a/AVOS/AVOS.xcodeproj/project.pbxproj
+++ b/AVOS/AVOS.xcodeproj/project.pbxproj
@@ -1230,6 +1230,10 @@
 		9A404DE01CE5A9C400DEB3DC /* LCRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = 83F9A2C61CE014430002E21B /* LCRouter.m */; };
 		9A404DE11CE5A9C400DEB3DC /* LCRouterCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 838B32E91CE032F800CAEBF8 /* LCRouterCache.h */; };
 		9A404DE21CE5A9C400DEB3DC /* LCRouterCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 838B32EA1CE032F800CAEBF8 /* LCRouterCache.m */; };
+		9A616B671E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A616B651E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.h */; };
+		9A616B681E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A616B651E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.h */; };
+		9A616B691E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A616B661E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.m */; };
+		9A616B6A1E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A616B661E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.m */; };
 		9A62AE591DF8145400EE0973 /* TestTypedMessage.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A62AE551DF813C100EE0973 /* TestTypedMessage.json */; };
 		9A62AE5B1DF8145900EE0973 /* TestTypedMessage.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A62AE551DF813C100EE0973 /* TestTypedMessage.json */; };
 		9A7C67D71C3FDD1D00B08D4F /* AVIMDirectCommand+DirectCommandAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A7C67D51C3FDD1D00B08D4F /* AVIMDirectCommand+DirectCommandAdditions.h */; };
@@ -1860,6 +1864,9 @@
 		9A2F1ABF1CF6F6FA00BE52F2 /* LCIMWellKnownTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LCIMWellKnownTypes.m; sourceTree = "<group>"; };
 		9A2F1AC01CF6F6FA00BE52F2 /* LCIMWireFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LCIMWireFormat.h; sourceTree = "<group>"; };
 		9A2F1AC11CF6F6FA00BE52F2 /* LCIMWireFormat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LCIMWireFormat.m; sourceTree = "<group>"; };
+		9A616B651E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LCIMMessageReceiptCacheStore.h; sourceTree = "<group>"; };
+		9A616B661E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LCIMMessageReceiptCacheStore.m; sourceTree = "<group>"; };
+		9A616B6B1E1EA6B7005F70F2 /* LCIMMessageReceiptCacheStoreSQL.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LCIMMessageReceiptCacheStoreSQL.h; sourceTree = "<group>"; };
 		9A62AE551DF813C100EE0973 /* TestTypedMessage.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TestTypedMessage.json; sourceTree = "<group>"; };
 		9A7C67D51C3FDD1D00B08D4F /* AVIMDirectCommand+DirectCommandAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "AVIMDirectCommand+DirectCommandAdditions.h"; sourceTree = "<group>"; };
 		9A7C67D61C3FDD1D00B08D4F /* AVIMDirectCommand+DirectCommandAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AVIMDirectCommand+DirectCommandAdditions.m"; sourceTree = "<group>"; };
@@ -2291,6 +2298,9 @@
 				83F745EE1B91732D00437259 /* LCIMMessageCacheStore.h */,
 				83F745EF1B91732D00437259 /* LCIMMessageCacheStore.m */,
 				83F745F01B91732D00437259 /* LCIMMessageCacheStoreSQL.h */,
+				9A616B651E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.h */,
+				9A616B661E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.m */,
+				9A616B6B1E1EA6B7005F70F2 /* LCIMMessageReceiptCacheStoreSQL.h */,
 				83F745F81B9177DE00437259 /* LCIMConversationCacheStore.h */,
 				83F745F91B9177DE00437259 /* LCIMConversationCacheStore.m */,
 				83F745FC1B9177F100437259 /* LCIMConversationCacheStoreSQL.h */,
@@ -3121,6 +3131,7 @@
 				9AE76C561C3F7CC600325902 /* AVIMDynamicObject.h in Headers */,
 				9A2F1B301CF6F6FA00BE52F2 /* LCIMExtensionInternals.h in Headers */,
 				704F3BF31BE0D0820033245C /* AVIMAudioMessage.h in Headers */,
+				9A616B681E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.h in Headers */,
 				704F3BF41BE0D0820033245C /* AVIMImageMessage.h in Headers */,
 				704F3BF51BE0D0820033245C /* AVIMLocationMessage.h in Headers */,
 				704F3BF61BE0D0820033245C /* AVIMTextMessage.h in Headers */,
@@ -3754,6 +3765,7 @@
 				8C9A927C1A70AF1800CA4912 /* AVIMVideoMessage.h in Headers */,
 				833E1F631B69F629002A691C /* AVIMFileMessage.h in Headers */,
 				830EB9E51C3F996A00BA917F /* AVIMClientOpenOption.h in Headers */,
+				9A616B671E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.h in Headers */,
 				9A2F1B491CF6F6FA00BE52F2 /* LCIMRootObject.h in Headers */,
 				8C9A927A1A70AF1800CA4912 /* AVIMTypedMessage.h in Headers */,
 				9A2F1B701CF6F6FA00BE52F2 /* LCIMWellKnownTypes.h in Headers */,
@@ -4254,6 +4266,7 @@
 				9AD27C521E1418DB002F9C7C /* LCIMFieldMask.pbobjc.m in Sources */,
 				9AE76C521C3F7CC600325902 /* AVIMGenericCommand+AVIMMessagesAdditions.m in Sources */,
 				83AB6DFA1C3CFEA70064BE17 /* AVOSCloudIM.m in Sources */,
+				9A616B6A1E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.m in Sources */,
 				9A2F1B5A1CF6F6FA00BE52F2 /* LCIMUnknownField.m in Sources */,
 				704F3BAB1BE0D05C0033245C /* LCIMCacheStore.m in Sources */,
 				704F3BAC1BE0D05C0033245C /* LCIMMessageCacheStore.m in Sources */,
@@ -4800,6 +4813,7 @@
 				9AD27C511E1418DB002F9C7C /* LCIMFieldMask.pbobjc.m in Sources */,
 				834B4A8F1B93ED3F00A7ADBC /* LCIMConversationCache.m in Sources */,
 				8CBDFDE31A808EA500D67FBE /* AVIMConversationQuery.m in Sources */,
+				9A616B691E1EA69C005F70F2 /* LCIMMessageReceiptCacheStore.m in Sources */,
 				9A2F1B581CF6F6FA00BE52F2 /* LCIMUnknownField.m in Sources */,
 				8C841C0F1A5A84C600C5C6C4 /* AVIMCommon.m in Sources */,
 				838AF12B1AFE58F600B8965E /* LCIMMessageCache.m in Sources */,

--- a/AVOS/AVOSCloud/Utils/UserAgent.h
+++ b/AVOS/AVOSCloud/Utils/UserAgent.h
@@ -1,1 +1,1 @@
-#define SDK_VERSION @"v3.10.0"
+#define SDK_VERSION @"v3.11.0"

--- a/AVOS/AVOSCloudIM/AVIMClient.h
+++ b/AVOS/AVOSCloudIM/AVIMClient.h
@@ -247,6 +247,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)conversation:(AVIMConversation *)conversation messageDelivered:(AVIMMessage *)message;
 
 /*!
+ 消息对方已读。
+ @param conversation － 所属对话
+ @param message - 具体的消息
+ */
+- (void)conversation:(AVIMConversation *)conversation messageRead:(AVIMMessage *)message;
+/*!
  对话中有新成员加入时所有成员都会收到这一通知。
  @param conversation － 所属对话
  @param clientIds - 加入的新成员列表

--- a/AVOS/AVOSCloudIM/AVIMClient.h
+++ b/AVOS/AVOSCloudIM/AVIMClient.h
@@ -277,7 +277,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)conversation:(AVIMConversation *)conversation kickedByClientId:(NSString *)clientId;
 
 /*!
-  收到未读通知。在该终端上线的时候，服务器会将对话的未读数发送过来。未读数可通过 -[AVIMConversation markAsReadInBackground] 清零，服务端不会自动清零。
+  收到未读通知。在该终端上线的时候，服务器会将对话的未读数发送过来。未读数可通过 -[AVIMConversation markAsReadInBackgroundForMessage:callback:] 清零，服务端不会自动清零。
  @param conversation 所属会话。
  @param unread 未读消息数量。
  */

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -1044,11 +1044,8 @@ static BOOL AVIMClientHasInstantiated = NO;
         LCIMMessageReceiptCacheStore *messageStatusCacheStore = [[LCIMMessageReceiptCacheStore alloc] initWithClientId:self.clientId conversationId:message.conversationId];
         [messageStatusCacheStore insertMessage:message];
         
-        // Step 2 : update Message Read Status
-        /*原来的实现：只更新单条消息的回执状态，新的实现：更新之前所有消息的状态。
-         *
-         LCIMMessageCacheStore *cacheStore = [[LCIMMessageCacheStore alloc] initWithClientId:self.clientId conversationId:message.conversationId];
-         [cacheStore updateMessageWithoutBreakpoint:message];
+        /* Step 2 : update Message Read Status
+        原来的实现：只更新单条消息的回执状态，新的实现：更新之前所有消息的状态。
          */
         LCIMMessageCacheStore *cacheStore = [[LCIMMessageCacheStore alloc] initWithClientId:self.clientId conversationId:message.conversationId];
         NSArray *messageBeforeTimestamp = @[];

--- a/AVOS/AVOSCloudIM/AVIMConversation.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation.h
@@ -164,10 +164,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)unmuteWithCallback:(AVIMBooleanResultBlock)callback;
 
 /*!
- 标记该会话已读。
- 将服务端该会话的未读消息数置零。
+ 标记该消息已读。
+ @param message - 需要标记为已读状态的消息
+ @attention 服务端会将该消息之前的消息状态都标记为已读。
  */
-- (void)markAsReadInBackground;
+- (void)markAsReadInBackgroundForMessage:(AVIMMessage *)message;
+
+/*!
+ 标记该消息已读。
+ @param message - 需要标记为已读状态的消息
+ @param callback － 结果回调
+ @attention 服务端会将该消息之前的消息状态都标记为已读。
+ */
+- (void)markAsReadInBackgroundForMessage:(AVIMMessage *)message callback:(AVIMBooleanResultBlock)callback;
 
 /*!
  邀请新成员加入对话。
@@ -280,6 +289,12 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface AVIMConversation (AVDeprecated)
+
+/*!
+ 标记该会话已读。
+ 将服务端该会话的未读消息数置零。
+ */
+- (void)markAsReadInBackground AVIM_DEPRECATED("Deprecated in AVOSCloudIM SDK 3.8.0. Use -[AVIMConversation markAsReadInBackgroundForMessage:callback:] instead.");
 
 /*!
  往对话中发送消息。

--- a/AVOS/AVOSCloudIM/AVIMConversation.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation.h
@@ -164,19 +164,23 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)unmuteWithCallback:(AVIMBooleanResultBlock)callback;
 
 /*!
- 标记该消息已读。
- @param message - 需要标记为已读状态的消息
- @attention 服务端会将该消息之前的消息状态都标记为已读。
+ 标记该会话已读。
+ 将服务端该会话的未读消息数置零。
  */
-- (void)markAsReadInBackgroundForMessage:(AVIMMessage *)message;
+- (void)markAsReadInBackground;
 
 /*!
  标记该消息已读。
- @param message - 需要标记为已读状态的消息
- @param callback － 结果回调
- @attention 服务端会将该消息之前的消息状态都标记为已读。
+ @attention 服务端会将对话最后一条消息之前的消息状态都标记为已读。
  */
-- (void)markAsReadInBackgroundForMessage:(AVIMMessage *)message callback:(AVIMBooleanResultBlock)callback;
+- (void)markAsReadInBackgroundForLastMessage;
+
+/*!
+ 标记该消息已读。
+ @param callback － 结果回调
+ @attention 服务端会将对话最后一条消息之前的消息状态都标记为已读。
+ */
+- (void)markAsReadInBackgroundForLastMessageWithCallback:(AVIMBooleanResultBlock)callback;
 
 /*!
  邀请新成员加入对话。
@@ -294,12 +298,6 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface AVIMConversation (AVDeprecated)
-
-/*!
- 标记该会话已读。
- 将服务端该会话的未读消息数置零。
- */
-- (void)markAsReadInBackground AVIM_DEPRECATED("Deprecated in AVOSCloudIM SDK 3.8.0. Use -[AVIMConversation markAsReadInBackgroundForMessage:callback:] instead.");
 
 /*!
  往对话中发送消息。

--- a/AVOS/AVOSCloudIM/AVIMConversation.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation.h
@@ -285,6 +285,11 @@ NS_ASSUME_NONNULL_BEGIN
                     timestamp:(int64_t)timestamp
                         limit:(NSUInteger)limit
                      callback:(AVIMArrayResultBlock)callback;
+/*!
+ * 拉取服务器最新的回执数据。
+ * 该方法仅对“单聊”(也即：成员数为2的对话)有效
+ */
+- (void)fetchLatestReceiptTimestampIfNeededWithCallback:(AVIMBooleanResultBlock)callback;
 
 @end
 

--- a/AVOS/AVOSCloudIM/AVIMConversation.m
+++ b/AVOS/AVOSCloudIM/AVIMConversation.m
@@ -24,7 +24,7 @@
 #import "AVIMUserOptions.h"
 #import "AVIMErrorUtil.h"
 #import "LCIMConversationCache.h"
-#import "MessagesProtoOrig.pbobjc.h
+#import "MessagesProtoOrig.pbobjc.h"
 #import "AVUtils.h"
 #import "LCIMMessageReceiptCacheStore.h"
 

--- a/AVOS/AVOSCloudIM/AVIMConversation.m
+++ b/AVOS/AVOSCloudIM/AVIMConversation.m
@@ -24,8 +24,9 @@
 #import "AVIMUserOptions.h"
 #import "AVIMErrorUtil.h"
 #import "LCIMConversationCache.h"
-#import "MessagesProtoOrig.pbobjc.h"
+#import "MessagesProtoOrig.pbobjc.h
 #import "AVUtils.h"
+#import "LCIMMessageReceiptCacheStore.h"
 
 #define LCIM_VALID_LIMIT(limit) ({      \
     int32_t limit_ = (int32_t)(limit);  \
@@ -793,6 +794,13 @@
     return clientId ? [[LCIMConversationCache alloc] initWithClientId:clientId] : nil;
 }
 
+- (LCIMMessageReceiptCacheStore *)messageReceiptCacheStore {
+    NSString *clientId = self.clientId;
+    NSString *conversationId = self.conversationId;
+    
+    return clientId && conversationId ? [[LCIMMessageReceiptCacheStore alloc] initWithClientId:clientId conversationId:conversationId] : nil;
+}
+
 - (void)cacheContinuousMessages:(NSArray *)messages {
     [self cacheContinuousMessages:messages withBreakpoint:YES];
 }
@@ -877,6 +885,7 @@
                     message.sendTimestamp = [logsItem timestamp];
                     message.clientId = [logsItem from];
                     message.messageId = [logsItem msgId];
+                    [self addReceiptStatusForMessage:message];
                     [messages addObject:message];
                 }
                 self.lastMessage = messages.lastObject;
@@ -1129,9 +1138,103 @@
 
 - (void)postprocessMessages:(NSArray *)messages {
     for (AVIMMessage *message in messages) {
-        message.status = AVIMMessageStatusSent;
         message.localClientId = self.imClient.clientId;
     }
+}
+
+- (int64_t)latestReadTimestampFromPeerFromPeer {
+    if (_latestReadTimestampFromPeer) {
+        return _latestReadTimestampFromPeer;
+    }
+    _latestReadTimestampFromPeer = [self.messageReceiptCacheStore latestReadTimestampFromPeer];
+    return _latestReadTimestampFromPeer;
+}
+
+- (int64_t)latestDeliveredTimestampFromPeer {
+    if (_latestDeliveredTimestampFromPeer) {
+        return _latestDeliveredTimestampFromPeer;
+    }
+    _latestDeliveredTimestampFromPeer = [self.messageReceiptCacheStore latestDeliveredTimestampFromPeer];
+    return _latestDeliveredTimestampFromPeer;
+}
+
+- (void)addReceiptStatusForMessage:(AVIMMessage *)message {
+    if (message.clientId != self.clientId) {
+        return;
+    }
+    message.status = AVIMMessageStatusSent;
+    
+    int64_t readTimestamp = self.latestReadTimestampFromPeer;
+    int64_t deliveredTimestamp = self.latestDeliveredTimestampFromPeer;
+    
+    if (deliveredTimestamp > 0) {
+        message.deliveredTimestamp = deliveredTimestamp;
+        if (message.sendTimestamp <= deliveredTimestamp) {
+            message.status = AVIMMessageStatusDelivered;
+        }
+    }
+    if (readTimestamp > 0) {
+        message.readTimestamp = readTimestamp;
+        if (message.sendTimestamp <= readTimestamp){
+            message.status = AVIMMessageStatusRead;
+        }
+    }
+}
+
+- (void)fetchLatestReceiptTimestampIfNeededWithCallback:(AVIMBooleanResultBlock)callback {
+    if (self.members.count != 2) {
+        NSError *error = [AVErrorUtils errorWithCode:0 errorText:@"`-[AVIMConversation fetchLatestReceiptTimestampIfNeededWithCallback:]` is only available for conversation with 2 members"];
+        [AVIMBlockHelper callBooleanResultBlock:callback error:error];
+        return;
+    }
+    [self fetchLatestReceiptTimestampWithCallback:callback];
+}
+
+- (void)fetchLatestReceiptTimestampWithCallback:(AVIMBooleanResultBlock)callback {
+    dispatch_async([AVIMClient imClientQueue], ^{
+        AVIMGenericCommand *genericCommand = [[AVIMGenericCommand alloc] init];
+        genericCommand.needResponse = YES;
+        genericCommand.cmd = AVIMCommandType_Conv;
+        genericCommand.peerId = _imClient.clientId;
+        genericCommand.op = AVIMOpType_MaxRead;
+        
+        AVIMConvCommand *command = [[AVIMConvCommand alloc] init];
+        command.cid = self.conversationId;
+        [genericCommand avim_addRequiredKeyWithCommand:command];
+        
+        [genericCommand setCallback:^(AVIMGenericCommand *outCommand_, AVIMGenericCommand *inCommand, NSError *error) {
+            if (!error) {
+                AVIMConvCommand *conversationInCommand = inCommand.convMessage;
+                
+                int64_t deliveredTimestamp = conversationInCommand.maxAckTimestamp;
+                int64_t readTimestamp = conversationInCommand.maxReadTimestamp;
+                AVIMMessage *rcpMessage = [[AVIMMessage alloc] init];
+                rcpMessage.status = AVIMMessageStatusDelivered;
+                rcpMessage.deliveredTimestamp = deliveredTimestamp;
+                rcpMessage.conversationId = self.conversationId;
+                rcpMessage.clientId = self.clientId;
+                LCIMMessageReceiptCacheStore *messageStatusCacheStore = self.messageReceiptCacheStore;
+                
+                if (deliveredTimestamp > 0) {
+                    [messageStatusCacheStore insertMessage:rcpMessage];
+                    self.latestDeliveredTimestampFromPeer = deliveredTimestamp;
+                }
+                
+                if (readTimestamp > 0) {
+                    rcpMessage.readTimestamp = readTimestamp;
+                    rcpMessage.status = AVIMMessageStatusRead;
+                    [messageStatusCacheStore insertMessage:rcpMessage];
+                    self.latestReadTimestampFromPeer = readTimestamp;
+                }
+                
+                [AVIMBlockHelper callBooleanResultBlock:callback error:nil];
+            } else {
+                [AVIMBlockHelper callBooleanResultBlock:callback error:error];
+            }
+        }];
+        
+        [_imClient sendCommand:genericCommand];
+    });
 }
 
 #pragma mark - Keyed Conversation

--- a/AVOS/AVOSCloudIM/AVIMConversation.m
+++ b/AVOS/AVOSCloudIM/AVIMConversation.m
@@ -391,40 +391,26 @@
 }
 
 - (void)markAsReadInBackground {
-    NSDictionary *userOptions = [AVIMClient userOptions];
-    NSArray *userOptionCustomProtocols = userOptions[AVIMUserOptionCustomProtocols];
-    BOOL isUseProtobuf2 = [userOptionCustomProtocols containsObject:AVIMProtocolPROTOBUF2];
-    BOOL isUseJson2 = [userOptionCustomProtocols containsObject:AVIMProtocolJSON2];
-    BOOL isUserProtocol2 = isUseProtobuf2 || isUseJson2;
-    
-    if (!isUserProtocol2) {
-        AVLoggerInfo(AVLoggerDomainIM, @"`-markAsReadInBackground` can be used only when you set custom protocols like AVIMProtocolJSON2 or AVIMProtocolPROTOBUF2. Otherwise, you should use `-markAsReadInBackgroundForMessage:callback:` instead.");
-        return;
-    }
-    __weak typeof(self) ws = self;
-    
-    dispatch_async([AVIMClient imClientQueue], ^{
-        [ws.imClient sendCommand:({
-            AVIMGenericCommand *genericCommand = [[AVIMGenericCommand alloc] init];
-            genericCommand.needResponse = YES;
-            genericCommand.cmd = AVIMCommandType_Read;
-            genericCommand.peerId = ws.imClient.clientId;
-            
-            AVIMReadCommand *readCommand = [[AVIMReadCommand alloc] init];
-            readCommand.cid = ws.conversationId;
-            [genericCommand avim_addRequiredKeyWithCommand:readCommand];
-            genericCommand;
-        })];
-    });
-}
-
-- (void)markAsReadInBackgroundForMessage:(AVIMMessage *)message {
-    [self markAsReadInBackgroundForMessage:message callback:^(BOOL succeeded, NSError * _Nullable error) {
+    [self markAsReadInBackgroundWithTriggerReceipt:NO callback:^(BOOL succeeded, NSError * _Nullable error) {
         //ignore callback
     }];
 }
 
-- (void)markAsReadInBackgroundForMessage:(AVIMMessage *)message callback:(AVIMBooleanResultBlock)callback {
+- (void)markAsReadInBackgroundForLastMessage {
+    [self markAsReadInBackgroundForLastMessage:YES];
+}
+
+- (void)markAsReadInBackgroundForLastMessageWithCallback:(AVIMBooleanResultBlock)callback {
+    [self markAsReadInBackgroundWithTriggerReceipt:YES callback:callback];
+}
+
+- (void)markAsReadInBackgroundForLastMessage:(BOOL)isForLastMessage {
+    [self markAsReadInBackgroundWithTriggerReceipt:YES callback:^(BOOL succeeded, NSError * _Nullable error) {
+        //ignore callback
+    }];
+}
+
+- (void)markAsReadInBackgroundWithTriggerReceipt:(BOOL)triggerReceipt callback:(AVIMBooleanResultBlock)callback {
     __weak typeof(self) ws = self;
     dispatch_async([AVIMClient imClientQueue], ^{
         [ws.imClient sendCommand:({
@@ -434,13 +420,17 @@
             genericCommand.peerId = ws.imClient.clientId;
             
             AVIMReadTuple *readTuple = [[AVIMReadTuple alloc] init];
-            readTuple.mid = message.messageId;
             readTuple.cid = ws.conversationId;
-            readTuple.timestamp = message.sendTimestamp;
+            if (triggerReceipt) {
+                readTuple.mid = self.lastMessage.messageId;
+                readTuple.timestamp = self.lastMessage.sendTimestamp;
+            }
+            
             NSMutableArray *convsArray = [@[readTuple] mutableCopy];
 
             AVIMReadCommand *readCommand = [[AVIMReadCommand alloc] init];
             readCommand.convsArray = convsArray;
+            readCommand.triggerReceipt = triggerReceipt;
             [genericCommand avim_addRequiredKeyWithCommand:readCommand];
             [genericCommand setCallback:^(AVIMGenericCommand *outCommand, AVIMGenericCommand *inCommand, NSError *error) {
                 [AVIMBlockHelper callBooleanResultBlock:callback error:error];

--- a/AVOS/AVOSCloudIM/AVIMConversation_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation_Internal.h
@@ -34,6 +34,10 @@
 @property (nonatomic, assign) BOOL          transient;       /**< 是否为临时会话（开放群组） */
 @property (nonatomic, strong) AVIMMessage  *lastMessage;     /**< 对话中最后一条消息 */
 
+@property (nonatomic, assign) int64_t latestReadTimestampFromPeer;
+
+@property (nonatomic, assign) int64_t latestDeliveredTimestampFromPeer;
+
 - (instancetype)initWithConversationId:(NSString *)conversationId;
 - (void)setConversationId:(NSString *)conversationId;
 - (void)setMembers:(NSArray *)members;

--- a/AVOS/AVOSCloudIM/AVIMMessage.h
+++ b/AVOS/AVOSCloudIM/AVIMMessage.h
@@ -19,6 +19,7 @@ typedef NS_ENUM(int8_t, AVIMMessageStatus) {
     AVIMMessageStatusSent,
     AVIMMessageStatusDelivered,
     AVIMMessageStatusFailed,
+    AVIMMessageStatusRead
 };
 
 NS_ASSUME_NONNULL_BEGIN
@@ -65,6 +66,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) int64_t deliveredTimestamp;
 
+/*!
+ * 已读时间（精确到毫秒）
+ */
+@property (nonatomic, assign) int64_t readTimestamp;
 /*!
  * 是否是暂态消息
  */

--- a/AVOS/AVOSCloudIM/AVIMMessage.m
+++ b/AVOS/AVOSCloudIM/AVIMMessage.m
@@ -44,6 +44,7 @@
         message.content = _content;
         message.sendTimestamp = _sendTimestamp;
         message.deliveredTimestamp = _deliveredTimestamp;
+        message.readTimestamp = _readTimestamp;
         //        message.requestReceipt = _requestReceipt;
     }
     return message;
@@ -63,6 +64,9 @@
     if (self.deliveredTimestamp != 0) {
         object.deliveredTimestamp = self.deliveredTimestamp;
     }
+    if (self.readTimestamp != 0) {
+        object.readTimestamp = self.readTimestamp;
+    }
     NSData *data = [object messagePack];
     [coder encodeObject:data forKey:@"data"];
     [coder encodeObject:self.localClientId forKey:NSStringFromSelector(@selector(localClientId))];
@@ -79,6 +83,7 @@
         self.content = object.content;
         self.sendTimestamp = object.sendTimestamp;
         self.deliveredTimestamp = object.deliveredTimestamp;
+        self.readTimestamp = object.readTimestamp;
         self.localClientId = [coder decodeObjectForKey:NSStringFromSelector(@selector(localClientId))];
     }
     return self;

--- a/AVOS/AVOSCloudIM/Commands/AVIMGenericCommand+AVIMMessagesAdditions.m
+++ b/AVOS/AVOSCloudIM/Commands/AVIMGenericCommand+AVIMMessagesAdditions.m
@@ -97,6 +97,9 @@ static uint16_t _searial_id = 0;
         case AVIMCommandType_Report:
             self.reportMessage = (AVIMReportCommand *)command;
             break;
+
+        case AVIMCommandType_Echo:
+            break;
     }
 }
 
@@ -433,6 +436,9 @@ static uint16_t _searial_id = 0;
             
         case AVIMCommandType_Report:
             result = self.reportMessage;
+            break;
+            
+        case AVIMCommandType_Echo:
             break;
     }
     return result;

--- a/AVOS/AVOSCloudIM/Commands/MessagesProtoOrig.pbobjc.h
+++ b/AVOS/AVOSCloudIM/Commands/MessagesProtoOrig.pbobjc.h
@@ -197,6 +197,8 @@ typedef GPB_ENUM(AVIMUnreadTuple_FieldNumber) {
   AVIMUnreadTuple_FieldNumber_Unread = 2,
   AVIMUnreadTuple_FieldNumber_Mid = 3,
   AVIMUnreadTuple_FieldNumber_Timestamp = 4,
+  AVIMUnreadTuple_FieldNumber_From = 5,
+  AVIMUnreadTuple_FieldNumber_Data_p = 6,
 };
 
 @interface AVIMUnreadTuple : LCIMMessage
@@ -215,6 +217,14 @@ typedef GPB_ENUM(AVIMUnreadTuple_FieldNumber) {
 @property(nonatomic, readwrite) int64_t timestamp;
 
 @property(nonatomic, readwrite) BOOL hasTimestamp;
+@property(nonatomic, readwrite, copy, null_resettable) NSString *from;
+/** Test to see if @c from has been set. */
+@property(nonatomic, readwrite) BOOL hasFrom;
+
+@property(nonatomic, readwrite, copy, null_resettable) NSString *data_p;
+/** Test to see if @c data_p has been set. */
+@property(nonatomic, readwrite) BOOL hasData_p;
+
 @end
 
 #pragma mark - AVIMLogItem
@@ -225,6 +235,7 @@ typedef GPB_ENUM(AVIMLogItem_FieldNumber) {
   AVIMLogItem_FieldNumber_Timestamp = 3,
   AVIMLogItem_FieldNumber_MsgId = 4,
   AVIMLogItem_FieldNumber_AckAt = 5,
+  AVIMLogItem_FieldNumber_ReadAt = 6,
 };
 
 @interface AVIMLogItem : LCIMMessage
@@ -247,6 +258,9 @@ typedef GPB_ENUM(AVIMLogItem_FieldNumber) {
 @property(nonatomic, readwrite) int64_t ackAt;
 
 @property(nonatomic, readwrite) BOOL hasAckAt;
+@property(nonatomic, readwrite) int64_t readAt;
+
+@property(nonatomic, readwrite) BOOL hasReadAt;
 @end
 
 #pragma mark - AVIMLoginCommand
@@ -297,6 +311,7 @@ typedef GPB_ENUM(AVIMSessionCommand_FieldNumber) {
   AVIMSessionCommand_FieldNumber_DeviceToken = 14,
   AVIMSessionCommand_FieldNumber_Sp = 15,
   AVIMSessionCommand_FieldNumber_Detail = 16,
+  AVIMSessionCommand_FieldNumber_LastUnreadNotifTime = 17,
 };
 
 @interface AVIMSessionCommand : LCIMMessage
@@ -360,6 +375,9 @@ typedef GPB_ENUM(AVIMSessionCommand_FieldNumber) {
 /** Test to see if @c detail has been set. */
 @property(nonatomic, readwrite) BOOL hasDetail;
 
+@property(nonatomic, readwrite) int64_t lastUnreadNotifTime;
+
+@property(nonatomic, readwrite) BOOL hasLastUnreadNotifTime;
 @end
 
 #pragma mark - AVIMErrorCommand
@@ -406,6 +424,7 @@ typedef GPB_ENUM(AVIMDirectCommand_FieldNumber) {
   AVIMDirectCommand_FieldNumber_Dt = 14,
   AVIMDirectCommand_FieldNumber_RoomId = 15,
   AVIMDirectCommand_FieldNumber_PushData = 16,
+  AVIMDirectCommand_FieldNumber_Will = 17,
 };
 
 @interface AVIMDirectCommand : LCIMMessage
@@ -461,6 +480,9 @@ typedef GPB_ENUM(AVIMDirectCommand_FieldNumber) {
 /** Test to see if @c pushData has been set. */
 @property(nonatomic, readwrite) BOOL hasPushData;
 
+@property(nonatomic, readwrite) BOOL will;
+
+@property(nonatomic, readwrite) BOOL hasWill;
 @end
 
 #pragma mark - AVIMAckCommand
@@ -526,6 +548,7 @@ typedef GPB_ENUM(AVIMAckCommand_FieldNumber) {
 
 typedef GPB_ENUM(AVIMUnreadCommand_FieldNumber) {
   AVIMUnreadCommand_FieldNumber_ConvsArray = 1,
+  AVIMUnreadCommand_FieldNumber_NotifTime = 2,
 };
 
 @interface AVIMUnreadCommand : LCIMMessage
@@ -534,6 +557,9 @@ typedef GPB_ENUM(AVIMUnreadCommand_FieldNumber) {
 /** The number of items in @c convsArray without causing the array to be created. */
 @property(nonatomic, readonly) NSUInteger convsArray_Count;
 
+@property(nonatomic, readwrite) int64_t notifTime;
+
+@property(nonatomic, readwrite) BOOL hasNotifTime;
 @end
 
 #pragma mark - AVIMConvCommand
@@ -630,7 +656,6 @@ typedef GPB_ENUM(AVIMConvCommand_FieldNumber) {
 @property(nonatomic, readwrite) int32_t statusTtl;
 
 @property(nonatomic, readwrite) BOOL hasStatusTtl;
-/** repeated string members = 19; */
 @property(nonatomic, readwrite, copy, null_resettable) NSString *targetClientId;
 /** Test to see if @c targetClientId has been set. */
 @property(nonatomic, readwrite) BOOL hasTargetClientId;
@@ -811,7 +836,6 @@ typedef GPB_ENUM(AVIMReadCommand_FieldNumber) {
   AVIMReadCommand_FieldNumber_Cid = 1,
   AVIMReadCommand_FieldNumber_CidsArray = 2,
   AVIMReadCommand_FieldNumber_ConvsArray = 3,
-  AVIMReadCommand_FieldNumber_TriggerReceipt = 4,
 };
 
 @interface AVIMReadCommand : LCIMMessage
@@ -828,9 +852,6 @@ typedef GPB_ENUM(AVIMReadCommand_FieldNumber) {
 /** The number of items in @c convsArray without causing the array to be created. */
 @property(nonatomic, readonly) NSUInteger convsArray_Count;
 
-@property(nonatomic, readwrite) BOOL triggerReceipt;
-
-@property(nonatomic, readwrite) BOOL hasTriggerReceipt;
 @end
 
 #pragma mark - AVIMPresenceCommand

--- a/AVOS/AVOSCloudIM/Commands/MessagesProtoOrig.pbobjc.h
+++ b/AVOS/AVOSCloudIM/Commands/MessagesProtoOrig.pbobjc.h
@@ -811,6 +811,7 @@ typedef GPB_ENUM(AVIMReadCommand_FieldNumber) {
   AVIMReadCommand_FieldNumber_Cid = 1,
   AVIMReadCommand_FieldNumber_CidsArray = 2,
   AVIMReadCommand_FieldNumber_ConvsArray = 3,
+  AVIMReadCommand_FieldNumber_TriggerReceipt = 4,
 };
 
 @interface AVIMReadCommand : LCIMMessage
@@ -827,6 +828,9 @@ typedef GPB_ENUM(AVIMReadCommand_FieldNumber) {
 /** The number of items in @c convsArray without causing the array to be created. */
 @property(nonatomic, readonly) NSUInteger convsArray_Count;
 
+@property(nonatomic, readwrite) BOOL triggerReceipt;
+
+@property(nonatomic, readwrite) BOOL hasTriggerReceipt;
 @end
 
 #pragma mark - AVIMPresenceCommand

--- a/AVOS/AVOSCloudIM/Commands/MessagesProtoOrig.pbobjc.h
+++ b/AVOS/AVOSCloudIM/Commands/MessagesProtoOrig.pbobjc.h
@@ -117,6 +117,7 @@ typedef GPB_ENUM(AVIMOpType) {
   AVIMOpType_Unmute = 48,
   AVIMOpType_Status = 49,
   AVIMOpType_Members = 50,
+  AVIMOpType_MaxRead = 51,
 
   /** room */
   AVIMOpType_Join = 80,
@@ -556,7 +557,9 @@ typedef GPB_ENUM(AVIMConvCommand_FieldNumber) {
   AVIMConvCommand_FieldNumber_StatusSub = 16,
   AVIMConvCommand_FieldNumber_StatusPub = 17,
   AVIMConvCommand_FieldNumber_StatusTtl = 18,
-  AVIMConvCommand_FieldNumber_MembersArray = 19,
+  AVIMConvCommand_FieldNumber_TargetClientId = 20,
+  AVIMConvCommand_FieldNumber_MaxReadTimestamp = 21,
+  AVIMConvCommand_FieldNumber_MaxAckTimestamp = 22,
   AVIMConvCommand_FieldNumber_Results = 100,
   AVIMConvCommand_FieldNumber_Where = 101,
   AVIMConvCommand_FieldNumber_Attr = 103,
@@ -627,10 +630,17 @@ typedef GPB_ENUM(AVIMConvCommand_FieldNumber) {
 @property(nonatomic, readwrite) int32_t statusTtl;
 
 @property(nonatomic, readwrite) BOOL hasStatusTtl;
-@property(nonatomic, readwrite, strong, null_resettable) NSMutableArray<NSString*> *membersArray;
-/** The number of items in @c membersArray without causing the array to be created. */
-@property(nonatomic, readonly) NSUInteger membersArray_Count;
+/** repeated string members = 19; */
+@property(nonatomic, readwrite, copy, null_resettable) NSString *targetClientId;
+/** Test to see if @c targetClientId has been set. */
+@property(nonatomic, readwrite) BOOL hasTargetClientId;
 
+@property(nonatomic, readwrite) int64_t maxReadTimestamp;
+
+@property(nonatomic, readwrite) BOOL hasMaxReadTimestamp;
+@property(nonatomic, readwrite) int64_t maxAckTimestamp;
+
+@property(nonatomic, readwrite) BOOL hasMaxAckTimestamp;
 @property(nonatomic, readwrite, strong, null_resettable) AVIMJsonObjectMessage *results;
 /** Test to see if @c results has been set. */
 @property(nonatomic, readwrite) BOOL hasResults;

--- a/AVOS/AVOSCloudIM/Commands/MessagesProtoOrig.pbobjc.m
+++ b/AVOS/AVOSCloudIM/Commands/MessagesProtoOrig.pbobjc.m
@@ -304,12 +304,16 @@ typedef struct AVIMJsonObjectMessage__storage_ {
 @dynamic hasUnread, unread;
 @dynamic hasMid, mid;
 @dynamic hasTimestamp, timestamp;
+@dynamic hasFrom, from;
+@dynamic hasData_p, data_p;
 
 typedef struct AVIMUnreadTuple__storage_ {
   uint32_t _has_storage_[1];
   int32_t unread;
   NSString *cid;
   NSString *mid;
+  NSString *from;
+  NSString *data_p;
   int64_t timestamp;
 } AVIMUnreadTuple__storage_;
 
@@ -355,6 +359,24 @@ typedef struct AVIMUnreadTuple__storage_ {
         .flags = LCIMFieldOptional,
         .dataType = GPBDataTypeInt64,
       },
+      {
+        .name = "from",
+        .dataTypeSpecific.className = NULL,
+        .number = AVIMUnreadTuple_FieldNumber_From,
+        .hasIndex = 4,
+        .offset = (uint32_t)offsetof(AVIMUnreadTuple__storage_, from),
+        .flags = LCIMFieldOptional,
+        .dataType = GPBDataTypeString,
+      },
+      {
+        .name = "data_p",
+        .dataTypeSpecific.className = NULL,
+        .number = AVIMUnreadTuple_FieldNumber_Data_p,
+        .hasIndex = 5,
+        .offset = (uint32_t)offsetof(AVIMUnreadTuple__storage_, data_p),
+        .flags = LCIMFieldOptional,
+        .dataType = GPBDataTypeString,
+      },
     };
     LCIMDescriptor *localDescriptor =
         [LCIMDescriptor allocDescriptorForClass:[AVIMUnreadTuple class]
@@ -381,6 +403,7 @@ typedef struct AVIMUnreadTuple__storage_ {
 @dynamic hasTimestamp, timestamp;
 @dynamic hasMsgId, msgId;
 @dynamic hasAckAt, ackAt;
+@dynamic hasReadAt, readAt;
 
 typedef struct AVIMLogItem__storage_ {
   uint32_t _has_storage_[1];
@@ -389,6 +412,7 @@ typedef struct AVIMLogItem__storage_ {
   NSString *msgId;
   int64_t timestamp;
   int64_t ackAt;
+  int64_t readAt;
 } AVIMLogItem__storage_;
 
 // This method is threadsafe because it is initially called
@@ -442,6 +466,15 @@ typedef struct AVIMLogItem__storage_ {
         .flags = (LCIMFieldFlags)(LCIMFieldOptional | LCIMFieldTextFormatNameCustom),
         .dataType = GPBDataTypeInt64,
       },
+      {
+        .name = "readAt",
+        .dataTypeSpecific.className = NULL,
+        .number = AVIMLogItem_FieldNumber_ReadAt,
+        .hasIndex = 5,
+        .offset = (uint32_t)offsetof(AVIMLogItem__storage_, readAt),
+        .flags = (LCIMFieldFlags)(LCIMFieldOptional | LCIMFieldTextFormatNameCustom),
+        .dataType = GPBDataTypeInt64,
+      },
     };
     LCIMDescriptor *localDescriptor =
         [LCIMDescriptor allocDescriptorForClass:[AVIMLogItem class]
@@ -453,7 +486,7 @@ typedef struct AVIMLogItem__storage_ {
                                          flags:LCIMDescriptorInitializationFlag_None];
 #if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     static const char *extraTextFormatInfo =
-        "\002\004\005\000\005\005\000";
+        "\003\004\005\000\005\005\000\006\006\000";
     [localDescriptor setupExtraTextInfo:extraTextFormatInfo];
 #endif  // !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     NSAssert(descriptor == nil, @"Startup recursed!");
@@ -578,6 +611,7 @@ typedef struct AVIMDataCommand__storage_ {
 @dynamic hasDeviceToken, deviceToken;
 @dynamic hasSp, sp;
 @dynamic hasDetail, detail;
+@dynamic hasLastUnreadNotifTime, lastUnreadNotifTime;
 
 typedef struct AVIMSessionCommand__storage_ {
   uint32_t _has_storage_[1];
@@ -595,6 +629,7 @@ typedef struct AVIMSessionCommand__storage_ {
   NSString *deviceToken;
   NSString *detail;
   int64_t t;
+  int64_t lastUnreadNotifTime;
 } AVIMSessionCommand__storage_;
 
 // This method is threadsafe because it is initially called
@@ -747,6 +782,15 @@ typedef struct AVIMSessionCommand__storage_ {
         .flags = LCIMFieldOptional,
         .dataType = GPBDataTypeString,
       },
+      {
+        .name = "lastUnreadNotifTime",
+        .dataTypeSpecific.className = NULL,
+        .number = AVIMSessionCommand_FieldNumber_LastUnreadNotifTime,
+        .hasIndex = 16,
+        .offset = (uint32_t)offsetof(AVIMSessionCommand__storage_, lastUnreadNotifTime),
+        .flags = (LCIMFieldFlags)(LCIMFieldOptional | LCIMFieldTextFormatNameCustom),
+        .dataType = GPBDataTypeInt64,
+      },
     };
     LCIMDescriptor *localDescriptor =
         [LCIMDescriptor allocDescriptorForClass:[AVIMSessionCommand class]
@@ -758,8 +802,8 @@ typedef struct AVIMSessionCommand__storage_ {
                                          flags:LCIMDescriptorInitializationFlag_None];
 #if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     static const char *extraTextFormatInfo =
-        "\005\007\010\000\010\000sessionPeerIds\000\t\000onlineSessionPeer"
-        "Ids\000\013\005\000\016\013\000";
+        "\006\007\010\000\010\000sessionPeerIds\000\t\000onlineSessionPeer"
+        "Ids\000\013\005\000\016\013\000\021\023\000";
     [localDescriptor setupExtraTextInfo:extraTextFormatInfo];
 #endif  // !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     NSAssert(descriptor == nil, @"Startup recursed!");
@@ -869,6 +913,7 @@ typedef struct AVIMErrorCommand__storage_ {
 @dynamic hasDt, dt;
 @dynamic hasRoomId, roomId;
 @dynamic hasPushData, pushData;
+@dynamic hasWill, will;
 
 typedef struct AVIMDirectCommand__storage_ {
   uint32_t _has_storage_[1];
@@ -1015,6 +1060,15 @@ typedef struct AVIMDirectCommand__storage_ {
         .offset = (uint32_t)offsetof(AVIMDirectCommand__storage_, pushData),
         .flags = (LCIMFieldFlags)(LCIMFieldOptional | LCIMFieldTextFormatNameCustom),
         .dataType = GPBDataTypeString,
+      },
+      {
+        .name = "will",
+        .dataTypeSpecific.className = NULL,
+        .number = AVIMDirectCommand_FieldNumber_Will,
+        .hasIndex = 17,
+        .offset = 18,  // Stored in _has_storage_ to save space.
+        .flags = LCIMFieldOptional,
+        .dataType = GPBDataTypeBool,
       },
     };
     LCIMDescriptor *localDescriptor =
@@ -1201,10 +1255,12 @@ typedef struct AVIMAckCommand__storage_ {
 @implementation AVIMUnreadCommand
 
 @dynamic convsArray, convsArray_Count;
+@dynamic hasNotifTime, notifTime;
 
 typedef struct AVIMUnreadCommand__storage_ {
   uint32_t _has_storage_[1];
   NSMutableArray *convsArray;
+  int64_t notifTime;
 } AVIMUnreadCommand__storage_;
 
 // This method is threadsafe because it is initially called
@@ -1222,6 +1278,15 @@ typedef struct AVIMUnreadCommand__storage_ {
         .flags = LCIMFieldRepeated,
         .dataType = GPBDataTypeMessage,
       },
+      {
+        .name = "notifTime",
+        .dataTypeSpecific.className = NULL,
+        .number = AVIMUnreadCommand_FieldNumber_NotifTime,
+        .hasIndex = 0,
+        .offset = (uint32_t)offsetof(AVIMUnreadCommand__storage_, notifTime),
+        .flags = (LCIMFieldFlags)(LCIMFieldOptional | LCIMFieldTextFormatNameCustom),
+        .dataType = GPBDataTypeInt64,
+      },
     };
     LCIMDescriptor *localDescriptor =
         [LCIMDescriptor allocDescriptorForClass:[AVIMUnreadCommand class]
@@ -1231,6 +1296,11 @@ typedef struct AVIMUnreadCommand__storage_ {
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
                                    storageSize:sizeof(AVIMUnreadCommand__storage_)
                                          flags:LCIMDescriptorInitializationFlag_None];
+#if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
+    static const char *extraTextFormatInfo =
+        "\001\002\t\000";
+    [localDescriptor setupExtraTextInfo:extraTextFormatInfo];
+#endif  // !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     NSAssert(descriptor == nil, @"Startup recursed!");
     descriptor = localDescriptor;
   }
@@ -1947,7 +2017,6 @@ typedef struct AVIMReadTuple__storage_ {
 @dynamic hasCid, cid;
 @dynamic cidsArray, cidsArray_Count;
 @dynamic convsArray, convsArray_Count;
-@dynamic hasTriggerReceipt, triggerReceipt;
 
 typedef struct AVIMReadCommand__storage_ {
   uint32_t _has_storage_[1];
@@ -1989,15 +2058,6 @@ typedef struct AVIMReadCommand__storage_ {
         .flags = LCIMFieldRepeated,
         .dataType = GPBDataTypeMessage,
       },
-      {
-        .name = "triggerReceipt",
-        .dataTypeSpecific.className = NULL,
-        .number = AVIMReadCommand_FieldNumber_TriggerReceipt,
-        .hasIndex = 1,
-        .offset = 2,  // Stored in _has_storage_ to save space.
-        .flags = (LCIMFieldFlags)(LCIMFieldOptional | LCIMFieldTextFormatNameCustom),
-        .dataType = GPBDataTypeBool,
-      },
     };
     LCIMDescriptor *localDescriptor =
         [LCIMDescriptor allocDescriptorForClass:[AVIMReadCommand class]
@@ -2007,11 +2067,6 @@ typedef struct AVIMReadCommand__storage_ {
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
                                    storageSize:sizeof(AVIMReadCommand__storage_)
                                          flags:LCIMDescriptorInitializationFlag_None];
-#if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
-    static const char *extraTextFormatInfo =
-        "\001\004\016\000";
-    [localDescriptor setupExtraTextInfo:extraTextFormatInfo];
-#endif  // !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     NSAssert(descriptor == nil, @"Startup recursed!");
     descriptor = localDescriptor;
   }
@@ -2432,8 +2487,7 @@ typedef struct AVIMGenericCommand__storage_ {
                                         fields:fields
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescriptionWithDefault))
                                    storageSize:sizeof(AVIMGenericCommand__storage_)
-         
-                                          flags:LCIMDescriptorInitializationFlag_FieldsWithDefault];
+                                         flags:LCIMDescriptorInitializationFlag_FieldsWithDefault];
 #if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     static const char *extraTextFormatInfo =
         "\021\003\005\000\004\006\000\006\016\000d\014\000e\013\000f\016\000g\014\000h\r\000i\n\000j\r\000k\013\000l\n\000m\013\000"

--- a/AVOS/AVOSCloudIM/Commands/MessagesProtoOrig.pbobjc.m
+++ b/AVOS/AVOSCloudIM/Commands/MessagesProtoOrig.pbobjc.m
@@ -1947,6 +1947,7 @@ typedef struct AVIMReadTuple__storage_ {
 @dynamic hasCid, cid;
 @dynamic cidsArray, cidsArray_Count;
 @dynamic convsArray, convsArray_Count;
+@dynamic hasTriggerReceipt, triggerReceipt;
 
 typedef struct AVIMReadCommand__storage_ {
   uint32_t _has_storage_[1];
@@ -1988,6 +1989,15 @@ typedef struct AVIMReadCommand__storage_ {
         .flags = LCIMFieldRepeated,
         .dataType = GPBDataTypeMessage,
       },
+      {
+        .name = "triggerReceipt",
+        .dataTypeSpecific.className = NULL,
+        .number = AVIMReadCommand_FieldNumber_TriggerReceipt,
+        .hasIndex = 1,
+        .offset = 2,  // Stored in _has_storage_ to save space.
+        .flags = (LCIMFieldFlags)(LCIMFieldOptional | LCIMFieldTextFormatNameCustom),
+        .dataType = GPBDataTypeBool,
+      },
     };
     LCIMDescriptor *localDescriptor =
         [LCIMDescriptor allocDescriptorForClass:[AVIMReadCommand class]
@@ -1997,6 +2007,11 @@ typedef struct AVIMReadCommand__storage_ {
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
                                    storageSize:sizeof(AVIMReadCommand__storage_)
                                          flags:LCIMDescriptorInitializationFlag_None];
+#if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
+    static const char *extraTextFormatInfo =
+        "\001\004\016\000";
+    [localDescriptor setupExtraTextInfo:extraTextFormatInfo];
+#endif  // !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     NSAssert(descriptor == nil, @"Startup recursed!");
     descriptor = localDescriptor;
   }
@@ -2417,7 +2432,8 @@ typedef struct AVIMGenericCommand__storage_ {
                                         fields:fields
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescriptionWithDefault))
                                    storageSize:sizeof(AVIMGenericCommand__storage_)
-                                         flags:LCIMDescriptorInitializationFlag_FieldsWithDefault];
+         
+                                          flags:LCIMDescriptorInitializationFlag_FieldsWithDefault];
 #if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     static const char *extraTextFormatInfo =
         "\021\003\005\000\004\006\000\006\016\000d\014\000e\013\000f\016\000g\014\000h\r\000i\n\000j\r\000k\013\000l\n\000m\013\000"

--- a/AVOS/AVOSCloudIM/Commands/MessagesProtoOrig.pbobjc.m
+++ b/AVOS/AVOSCloudIM/Commands/MessagesProtoOrig.pbobjc.m
@@ -117,9 +117,9 @@ LCIMEnumDescriptor *AVIMOpType_EnumDescriptor(void) {
         "y\000QueryResult\000Conflict\000Added\000Removed\000Sta"
         "rt\000Started\000Joined\000MembersJoined\000Left\000Mem"
         "bersLeft\000Results\000Count\000Result\000Update\000Upd"
-        "ated\000Mute\000Unmute\000Status\000Members\000Join\000Inv"
-        "ite\000Leave\000Kick\000Reject\000Invited\000Kicked\000Upl"
-        "oad\000Uploaded\000";
+        "ated\000Mute\000Unmute\000Status\000Members\000MaxRead\000"
+        "Join\000Invite\000Leave\000Kick\000Reject\000Invited\000Ki"
+        "cked\000Upload\000Uploaded\000";
     static const int32_t values[] = {
         AVIMOpType_Open,
         AVIMOpType_Add,
@@ -147,6 +147,7 @@ LCIMEnumDescriptor *AVIMOpType_EnumDescriptor(void) {
         AVIMOpType_Unmute,
         AVIMOpType_Status,
         AVIMOpType_Members,
+        AVIMOpType_MaxRead,
         AVIMOpType_Join,
         AVIMOpType_Invite,
         AVIMOpType_Leave,
@@ -157,7 +158,7 @@ LCIMEnumDescriptor *AVIMOpType_EnumDescriptor(void) {
         AVIMOpType_Upload,
         AVIMOpType_Uploaded,
     };
-    static const char *extraTextFormatInfo = "#\000$\000\001#\000\002&\000\003%\000\004&\000\005&\000\006%\000\007%\246\000\010(\000\t%\000\n\'\000\013%\000\014\'\000\r&\000\016\'\246\000\017$\000\020\'\244\000\021\'\000\022%\000\023&\000\024&\000\025\'\000\026$\000\027&\000\030&\000\031\'\000\032$\000\033&\000\034%\000\035$\000\036&\000\037\'\000 &\000!&\000\"(\000";
+    static const char *extraTextFormatInfo = "$\000$\000\001#\000\002&\000\003%\000\004&\000\005&\000\006%\000\007%\246\000\010(\000\t%\000\n\'\000\013%\000\014\'\000\r&\000\016\'\246\000\017$\000\020\'\244\000\021\'\000\022%\000\023&\000\024&\000\025\'\000\026$\000\027&\000\030&\000\031\'\000\032#\244\000\033$\000\034&\000\035%\000\036$\000\037&\000 \'\000!&\000\"&\000#(\000";
     LCIMEnumDescriptor *worker =
         [LCIMEnumDescriptor allocDescriptorForName:GPBNSStringifySymbol(AVIMOpType)
                                        valueNames:valueNames
@@ -200,6 +201,7 @@ BOOL AVIMOpType_IsValidValue(int32_t value__) {
     case AVIMOpType_Unmute:
     case AVIMOpType_Status:
     case AVIMOpType_Members:
+    case AVIMOpType_MaxRead:
     case AVIMOpType_Join:
     case AVIMOpType_Invite:
     case AVIMOpType_Leave:
@@ -1259,7 +1261,9 @@ typedef struct AVIMUnreadCommand__storage_ {
 @dynamic hasStatusSub, statusSub;
 @dynamic hasStatusPub, statusPub;
 @dynamic hasStatusTtl, statusTtl;
-@dynamic membersArray, membersArray_Count;
+@dynamic hasTargetClientId, targetClientId;
+@dynamic hasMaxReadTimestamp, maxReadTimestamp;
+@dynamic hasMaxAckTimestamp, maxAckTimestamp;
 @dynamic hasResults, results;
 @dynamic hasWhere, where;
 @dynamic hasAttr, attr;
@@ -1279,11 +1283,13 @@ typedef struct AVIMConvCommand__storage_ {
   NSString *udate;
   NSString *n;
   NSString *s;
-  NSMutableArray *membersArray;
+  NSString *targetClientId;
   AVIMJsonObjectMessage *results;
   AVIMJsonObjectMessage *where;
   AVIMJsonObjectMessage *attr;
   int64_t t;
+  int64_t maxReadTimestamp;
+  int64_t maxAckTimestamp;
 } AVIMConvCommand__storage_;
 
 // This method is threadsafe because it is initially called
@@ -1455,19 +1461,37 @@ typedef struct AVIMConvCommand__storage_ {
         .dataType = GPBDataTypeInt32,
       },
       {
-        .name = "membersArray",
+        .name = "targetClientId",
         .dataTypeSpecific.className = NULL,
-        .number = AVIMConvCommand_FieldNumber_MembersArray,
-        .hasIndex = GPBNoHasBit,
-        .offset = (uint32_t)offsetof(AVIMConvCommand__storage_, membersArray),
-        .flags = LCIMFieldRepeated,
+        .number = AVIMConvCommand_FieldNumber_TargetClientId,
+        .hasIndex = 21,
+        .offset = (uint32_t)offsetof(AVIMConvCommand__storage_, targetClientId),
+        .flags = (LCIMFieldFlags)(LCIMFieldOptional | LCIMFieldTextFormatNameCustom),
         .dataType = GPBDataTypeString,
+      },
+      {
+        .name = "maxReadTimestamp",
+        .dataTypeSpecific.className = NULL,
+        .number = AVIMConvCommand_FieldNumber_MaxReadTimestamp,
+        .hasIndex = 22,
+        .offset = (uint32_t)offsetof(AVIMConvCommand__storage_, maxReadTimestamp),
+        .flags = (LCIMFieldFlags)(LCIMFieldOptional | LCIMFieldTextFormatNameCustom),
+        .dataType = GPBDataTypeInt64,
+      },
+      {
+        .name = "maxAckTimestamp",
+        .dataTypeSpecific.className = NULL,
+        .number = AVIMConvCommand_FieldNumber_MaxAckTimestamp,
+        .hasIndex = 23,
+        .offset = (uint32_t)offsetof(AVIMConvCommand__storage_, maxAckTimestamp),
+        .flags = (LCIMFieldFlags)(LCIMFieldOptional | LCIMFieldTextFormatNameCustom),
+        .dataType = GPBDataTypeInt64,
       },
       {
         .name = "results",
         .dataTypeSpecific.className = GPBStringifySymbol(AVIMJsonObjectMessage),
         .number = AVIMConvCommand_FieldNumber_Results,
-        .hasIndex = 21,
+        .hasIndex = 24,
         .offset = (uint32_t)offsetof(AVIMConvCommand__storage_, results),
         .flags = LCIMFieldOptional,
         .dataType = GPBDataTypeMessage,
@@ -1476,7 +1500,7 @@ typedef struct AVIMConvCommand__storage_ {
         .name = "where",
         .dataTypeSpecific.className = GPBStringifySymbol(AVIMJsonObjectMessage),
         .number = AVIMConvCommand_FieldNumber_Where,
-        .hasIndex = 22,
+        .hasIndex = 25,
         .offset = (uint32_t)offsetof(AVIMConvCommand__storage_, where),
         .flags = LCIMFieldOptional,
         .dataType = GPBDataTypeMessage,
@@ -1485,7 +1509,7 @@ typedef struct AVIMConvCommand__storage_ {
         .name = "attr",
         .dataTypeSpecific.className = GPBStringifySymbol(AVIMJsonObjectMessage),
         .number = AVIMConvCommand_FieldNumber_Attr,
-        .hasIndex = 23,
+        .hasIndex = 26,
         .offset = (uint32_t)offsetof(AVIMConvCommand__storage_, attr),
         .flags = LCIMFieldOptional,
         .dataType = GPBDataTypeMessage,
@@ -1501,7 +1525,7 @@ typedef struct AVIMConvCommand__storage_ {
                                          flags:LCIMDescriptorInitializationFlag_None];
 #if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     static const char *extraTextFormatInfo =
-        "\004\006\006\000\020\t\000\021\t\000\022\007b\000";
+        "\007\006\006\000\020\t\000\021\t\000\022\007b\000\024\016\000\025\020\000\026\017\000";
     [localDescriptor setupExtraTextInfo:extraTextFormatInfo];
 #endif  // !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     NSAssert(descriptor == nil, @"Startup recursed!");

--- a/AVOS/AVOSCloudIM/InternalObjects/AVIMMessageObject.h
+++ b/AVOS/AVOSCloudIM/InternalObjects/AVIMMessageObject.h
@@ -18,5 +18,6 @@
 @property(nonatomic, strong)NSString *content;
 @property(nonatomic)int64_t sendTimestamp;
 @property(nonatomic)int64_t deliveredTimestamp;
+@property(nonatomic)int64_t readTimestamp;
 
 @end

--- a/AVOS/AVOSCloudIM/InternalObjects/AVIMMessageObject.m
+++ b/AVOS/AVOSCloudIM/InternalObjects/AVIMMessageObject.m
@@ -9,5 +9,5 @@
 #import "AVIMMessageObject.h"
 
 @implementation AVIMMessageObject
-@dynamic ioType, status, messageId, clientId, conversationId, content, sendTimestamp, deliveredTimestamp;
+@dynamic ioType, status, messageId, clientId, conversationId, content, sendTimestamp, deliveredTimestamp, readTimestamp;
 @end

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStore.h
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStore.h
@@ -8,7 +8,7 @@
 
 #import "LCIMCacheStore.h"
 
-@class AVIMMessage;
+#import "AVIMMessage.h"
 
 @interface LCIMMessageCacheStore : LCIMCacheStore
 
@@ -23,6 +23,9 @@
 - (void)updateBreakpoint:(BOOL)breakpoint forMessages:(NSArray *)messages;
 - (void)updateBreakpoint:(BOOL)breakpoint forMessage:(AVIMMessage *)message;
 
+- (void)updateReceiptTimestamp:(int64_t)timestamp
+                        status:(AVIMMessageStatus)status
+                   forMessages:(NSArray *)messages;
 - (void)updateMessageWithoutBreakpoint:(AVIMMessage *)message;
 
 - (void)deleteMessageForId:(NSString *)messageId;
@@ -36,6 +39,9 @@
 - (NSArray *)messagesBeforeTimestamp:(int64_t)timestamp
                            messageId:(NSString *)messageId
                                limit:(NSUInteger)limit;
+
+- (NSArray *)messagesBeforeTimestamp:(int64_t)timestamp
+                              status:(AVIMMessageStatus)status;
 
 - (NSArray *)latestMessagesWithLimit:(NSUInteger)limit;
 

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStore.m
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStore.m
@@ -38,6 +38,10 @@
 
     [migrator executeMigrations:@[
         // Migrations of each database version
+        /* Version 1: Add readTimestamp column. */
+        [LCDatabaseMigration migrationWithBlock:^(LCDatabase *db) {
+            [db executeUpdate:@"ALTER TABLE conversation ADD COLUMN read_timestamp NUMBERIC"];
+        }]
     ]];
 }
 
@@ -59,6 +63,10 @@
 - (NSNumber *)receiptTimestampForMessage:(AVIMMessage *)message {
     return [NSNumber numberWithDouble:message.deliveredTimestamp];
 }
+//TODO:add read time stamp
+- (NSNumber *)readTimestampForMessage:(AVIMMessage *)message {
+    return [NSNumber numberWithDouble:message.readTimestamp];
+}
 
 - (NSTimeInterval)currentTimestamp {
     return [[NSDate date] timeIntervalSince1970] * 1000;
@@ -69,6 +77,7 @@
         message.clientId,
         [self timestampForMessage:message],
         [self receiptTimestampForMessage:message],
+        [self readTimestampForMessage:message],
         [message.payload dataUsingEncoding:NSUTF8StringEncoding],
         @(message.status),
         self.conversationId,
@@ -83,6 +92,7 @@
         message.clientId,
         [self timestampForMessage:message],
         [self receiptTimestampForMessage:message],
+        [self readTimestampForMessage:message],
         [message.payload dataUsingEncoding:NSUTF8StringEncoding],
         @(message.status),
         @(NO)
@@ -96,6 +106,7 @@
         message.clientId,
         [self timestampForMessage:message],
         [self receiptTimestampForMessage:message],
+        [self readTimestampForMessage:message],
         [message.payload dataUsingEncoding:NSUTF8StringEncoding],
         @(message.status),
         @(breakpoint)

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStore.m
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStore.m
@@ -157,7 +157,6 @@
         return;
     }
     NSNumber *timestampNumber = [NSNumber numberWithDouble:timestamp];
-    NSLog(@"🔴类名与方法名：%@（在第%@行），描述：%@==%@", @(__PRETTY_FUNCTION__), @(__LINE__), timestampNumber, @(messages.count));
     if (!timestampNumber) {
         return;
     }
@@ -181,24 +180,7 @@
                               self.conversationId,
                               message.messageId
                               ];
-            
-            BOOL success ;
-            switch (status) {
-                case AVIMMessageStatusDelivered:
-                    //updateSQL = LCIM_SQL_UPDATE_MESSAGE_DELIVERED;
-                    success = [db executeUpdate:LCIM_SQL_UPDATE_MESSAGE_DELIVERED withArgumentsInArray:args];
-
-                    break;
-                case AVIMMessageStatusRead:
-                    //updateSQL = LCIM_SQL_UPDATE_MESSAGE_READ;
-                    success = [db executeUpdate:LCIM_SQL_UPDATE_MESSAGE_READ withArgumentsInArray:args];
-
-                    break;
-                default:
-                    break;
-            }
-            
-            NSLog(success ? @"==========YES" : @"=========NO");
+            [db executeUpdate:updateSQL withArgumentsInArray:args];
         }
     }));
 }

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStoreSQL.h
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStoreSQL.h
@@ -16,7 +16,6 @@
 #define LCIM_FIELD_FROM_PEER_ID         @"from_peer_id"
 #define LCIM_FIELD_TIMESTAMP            @"timestamp"
 #define LCIM_FIELD_RECEIPT_TIMESTAMP    @"receipt_timestamp"
-//TODO:add read time stamp
 #define LCIM_FIELD_READ_TIMESTAMP       @"read_timestamp"
 #define LCIM_FIELD_PAYLOAD              @"payload"
 #define LCIM_FIELD_BREAKPOINT           @"breakpoint"
@@ -45,34 +44,33 @@
         LCIM_FIELD_TIMESTAMP                                   \
     @")"
 
-#define LCIM_SQL_INSERT_MESSAGE                           \
-    @"INSERT OR REPLACE INTO " LCIM_TABLE_MESSAGE  @" ("  \
-        LCIM_FIELD_MESSAGE_ID           @", "             \
-        LCIM_FIELD_CONVERSATION_ID      @", "             \
-        LCIM_FIELD_FROM_PEER_ID         @", "             \
-        LCIM_FIELD_TIMESTAMP            @", "             \
-        LCIM_FIELD_RECEIPT_TIMESTAMP    @", "             \
-        LCIM_FIELD_READ_TIMESTAMP       @", "             \
-        LCIM_FIELD_PAYLOAD              @", "             \
-        LCIM_FIELD_STATUS               @", "             \
-        LCIM_FIELD_BREAKPOINT                             \
-    @") VALUES(?, ?, ?, ?, ?, ?, ?, ? ,? )"
-
-#define LCIM_SQL_UPDATE_MESSAGE                     \
-    @"UPDATE " LCIM_TABLE_MESSAGE        @" "       \
-    @"SET "                                         \
-        LCIM_FIELD_FROM_PEER_ID          @" = ?, "  \
-        LCIM_FIELD_TIMESTAMP             @" = ?, "  \
-        LCIM_FIELD_RECEIPT_TIMESTAMP     @" = ?, "  \
-        LCIM_FIELD_READ_TIMESTAMP        @" = ?, "  \
-        LCIM_FIELD_PAYLOAD               @" = ?, "  \
-        LCIM_FIELD_STATUS                @" = ? "   \
-    @"WHERE " LCIM_FIELD_CONVERSATION_ID @" = ? "   \
-    @"AND " LCIM_FIELD_MESSAGE_ID @" = ?"
+#define LCIM_SQL_INSERT_MESSAGE                             \
+    @"INSERT OR REPLACE INTO " LCIM_TABLE_MESSAGE  @" ("    \
+        LCIM_FIELD_MESSAGE_ID           @", "               \
+        LCIM_FIELD_CONVERSATION_ID      @", "               \
+        LCIM_FIELD_FROM_PEER_ID         @", "               \
+        LCIM_FIELD_TIMESTAMP            @", "               \
+        LCIM_FIELD_RECEIPT_TIMESTAMP    @", "               \
+        LCIM_FIELD_READ_TIMESTAMP       @", "/* Version 1 */\
+        LCIM_FIELD_PAYLOAD              @", "               \
+        LCIM_FIELD_STATUS               @", "               \
+        LCIM_FIELD_BREAKPOINT                               \
+    @") VALUES(?, ?, ?, ?, ?, ?, ?, ? , ?)"
 
 #define LCIM_SQL_MESSAGE_WHERE_CLAUSE              \
     @"WHERE " LCIM_FIELD_CONVERSATION_ID @" = ? "  \
     @"AND " LCIM_FIELD_MESSAGE_ID @" = ?"
+
+#define LCIM_SQL_UPDATE_MESSAGE                                  \
+    @"UPDATE " LCIM_TABLE_MESSAGE        @" "                    \
+    @"SET "                                                      \
+        LCIM_FIELD_FROM_PEER_ID          @" = ?, "               \
+        LCIM_FIELD_TIMESTAMP             @" = ?, "               \
+        LCIM_FIELD_RECEIPT_TIMESTAMP     @" = ?, "               \
+        LCIM_FIELD_READ_TIMESTAMP        @" = ?, "/* Version 1 */\
+        LCIM_FIELD_PAYLOAD               @" = ?, "               \
+        LCIM_FIELD_STATUS                @" = ? "                \
+    LCIM_SQL_MESSAGE_WHERE_CLAUSE
 
 #define LCIM_SQL_SELECT_MESSAGE_BY_ID              \
     @"SELECT * FROM " LCIM_TABLE_MESSAGE @" "      \
@@ -96,6 +94,14 @@
     @"ORDER BY " LCIM_FIELD_TIMESTAMP @" DESC, " LCIM_FIELD_MESSAGE_ID @" DESC "  \
     @"LIMIT ?"
 
+#define LCIM_SQL_SELECT_RECEIPT_MESSAGE_LESS_THAN_TIMESTAMP_AND_ID                \
+    @"SELECT * FROM " LCIM_TABLE_MESSAGE @" "                                    \
+    @"WHERE " LCIM_FIELD_CONVERSATION_ID @" = ? "                                \
+    @"AND (" LCIM_FIELD_TIMESTAMP @" < ? OR (" LCIM_FIELD_TIMESTAMP @" = ?))"      \
+    @"AND " LCIM_FIELD_STATUS @" < ? "                                           \
+    @"AND " LCIM_FIELD_FROM_PEER_ID @" = ? "                                     \
+    @"ORDER BY " LCIM_FIELD_TIMESTAMP @" DESC, " LCIM_FIELD_MESSAGE_ID @" DESC "
+
 #define LCIM_SQL_SELECT_NEXT_MESSAGE               \
     @"SELECT * FROM " LCIM_TABLE_MESSAGE @" "      \
     @"WHERE " LCIM_FIELD_CONVERSATION_ID @" = ? "  \
@@ -106,6 +112,20 @@
 #define LCIM_SQL_UPDATE_MESSAGE_BREAKPOINT        \
     @"UPDATE " LCIM_TABLE_MESSAGE @" "            \
     @"SET " LCIM_FIELD_BREAKPOINT @" = ? "        \
+    LCIM_SQL_MESSAGE_WHERE_CLAUSE
+
+#define LCIM_SQL_UPDATE_MESSAGE_DELIVERED         \
+    @"UPDATE " LCIM_TABLE_MESSAGE @" "            \
+    @"SET "                                       \
+        LCIM_FIELD_RECEIPT_TIMESTAMP @" = ? ,"    \
+        LCIM_FIELD_STATUS @" = ? "                \
+    LCIM_SQL_MESSAGE_WHERE_CLAUSE
+
+#define LCIM_SQL_UPDATE_MESSAGE_READ              \
+    @"UPDATE " LCIM_TABLE_MESSAGE @" "            \
+    @"SET "                                       \
+        LCIM_FIELD_READ_TIMESTAMP @" = ? ,"       \
+        LCIM_FIELD_STATUS @" = ? "                \
     LCIM_SQL_MESSAGE_WHERE_CLAUSE
 
 #define LCIM_SQL_DELETE_MESSAGE             \

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStoreSQL.h
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStoreSQL.h
@@ -16,6 +16,8 @@
 #define LCIM_FIELD_FROM_PEER_ID         @"from_peer_id"
 #define LCIM_FIELD_TIMESTAMP            @"timestamp"
 #define LCIM_FIELD_RECEIPT_TIMESTAMP    @"receipt_timestamp"
+//TODO:add read time stamp
+#define LCIM_FIELD_READ_TIMESTAMP       @"read_timestamp"
 #define LCIM_FIELD_PAYLOAD              @"payload"
 #define LCIM_FIELD_BREAKPOINT           @"breakpoint"
 #define LCIM_FIELD_STATUS               @"status"
@@ -50,10 +52,11 @@
         LCIM_FIELD_FROM_PEER_ID         @", "             \
         LCIM_FIELD_TIMESTAMP            @", "             \
         LCIM_FIELD_RECEIPT_TIMESTAMP    @", "             \
+        LCIM_FIELD_READ_TIMESTAMP       @", "             \
         LCIM_FIELD_PAYLOAD              @", "             \
         LCIM_FIELD_STATUS               @", "             \
         LCIM_FIELD_BREAKPOINT                             \
-    @") VALUES(?, ?, ?, ?, ?, ?, ?, ?)"
+    @") VALUES(?, ?, ?, ?, ?, ?, ?, ? ,? )"
 
 #define LCIM_SQL_UPDATE_MESSAGE                     \
     @"UPDATE " LCIM_TABLE_MESSAGE        @" "       \
@@ -61,6 +64,7 @@
         LCIM_FIELD_FROM_PEER_ID          @" = ?, "  \
         LCIM_FIELD_TIMESTAMP             @" = ?, "  \
         LCIM_FIELD_RECEIPT_TIMESTAMP     @" = ?, "  \
+        LCIM_FIELD_READ_TIMESTAMP        @" = ?, "  \
         LCIM_FIELD_PAYLOAD               @" = ?, "  \
         LCIM_FIELD_STATUS                @" = ? "   \
     @"WHERE " LCIM_FIELD_CONVERSATION_ID @" = ? "   \

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStoreSQL.h
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStoreSQL.h
@@ -30,6 +30,7 @@
         LCIM_FIELD_FROM_PEER_ID         @" TEXT, "           \
         LCIM_FIELD_TIMESTAMP            @" NUMBERIC, "       \
         LCIM_FIELD_RECEIPT_TIMESTAMP    @" NUMBERIC, "       \
+        LCIM_FIELD_READ_TIMESTAMP       @" NUMBERIC, "       \
         LCIM_FIELD_PAYLOAD              @" BLOB, "           \
         LCIM_FIELD_STATUS               @" INTEGER, "        \
         LCIM_FIELD_BREAKPOINT           @" BOOL, "           \

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageReceiptCacheStore.h
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageReceiptCacheStore.h
@@ -1,0 +1,30 @@
+//
+//  LCIMMessageReceiptCacheStore.h
+//  AVOS
+//
+//  Created by 陈宜龙 on 06/01/2017.
+//  Copyright © 2017 LeanCloud Inc. All rights reserved.
+//
+
+#import "LCIMCacheStore.h"
+@class AVIMMessage;
+@class AVIMConversation;
+
+@interface LCIMMessageReceiptCacheStore : LCIMCacheStore
+@property (nonatomic, readonly, copy) NSString *conversationId;
+
+- (instancetype)initWithClientId:(NSString *)clientId conversationId:(NSString *)conversationId;
+
+- (void)insertMessages:(NSArray *)messages;
+- (void)insertMessage:(AVIMMessage *)message;
+
+- (void)deleteConversation:(AVIMConversation *)conversation;
+
+- (void)updateMessages:(NSArray *)messages;
+- (void)updateMessage:(NSArray *)message;
+
+- (int64_t)latestReadTimestampFromPeer;
+
+- (int64_t)latestDeliveredTimestampFromPeer;
+
+@end

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageReceiptCacheStore.m
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageReceiptCacheStore.m
@@ -1,0 +1,161 @@
+//
+//  LCIMMessageReceiptCacheStore.m
+//  AVOS
+//
+//  Created by 陈宜龙 on 06/01/2017.
+//  Copyright © 2017 LeanCloud Inc. All rights reserved.
+//
+
+#import "LCIMMessageReceiptCacheStore.h"
+#import "LCIMMessageReceiptCacheStoreSQL.h"
+#import "AVIMMessage.h"
+#import "LCDatabaseMigrator.h"
+#import "AVIMConversation.h"
+#import "LCIMConversationCache.h"
+
+@interface LCIMMessageReceiptCacheStore ()
+
+@property (copy, readwrite) NSString *conversationId;
+
+@end
+
+@implementation LCIMMessageReceiptCacheStore
+
+- (void)databaseQueueDidLoad {
+    [self.databaseQueue inDatabase:^(LCDatabase *db) {
+        db.logsErrors = LCIM_SHOULD_LOG_ERRORS;
+        
+        [db executeUpdate:LCIM_SQL_CREATE_MESSAGE_RCP_TABLE];
+    }];
+    
+    [self migrateDatabaseIfNeeded:self.databaseQueue.path];
+}
+
+- (void)migrateDatabaseIfNeeded:(NSString *)databasePath {
+    LCDatabaseMigrator *migrator = [[LCDatabaseMigrator alloc] initWithDatabasePath:databasePath];
+    [migrator executeMigrations:@[
+                                  // Migrations of each database version
+                                  ]];
+}
+
+- (instancetype)initWithClientId:(NSString *)clientId conversationId:(NSString *)conversationId {
+    self = [super initWithClientId:clientId];
+    
+    if (self) {
+        _conversationId = [conversationId copy];
+    }
+    
+    return self;
+}
+
+- (void)insertMessages:(NSArray *)messages {
+    LCIM_OPEN_DATABASE(db, ({
+        for (AVIMMessage *message in messages) {
+            NSArray *args = [self insertionRecordForMessage:message];
+            [db executeUpdate:LCIM_SQL_INSERT_MESSAGE_RCP withArgumentsInArray:args];
+        }
+    }));
+}
+
+- (void)insertMessage:(AVIMMessage *)message {
+    [self insertMessages:@[message]];
+}
+
+- (void)deleteConversation:(AVIMConversation *)conversation {
+    [self deleteConversationForId:conversation.conversationId];
+}
+
+- (void)deleteConversationForId:(NSString *)conversationId {
+    if (!conversationId) return;
+    
+    LCIM_OPEN_DATABASE(db, ({
+        NSArray *args = @[conversationId];
+        [db executeUpdate:LCIM_SQL_DELETE_CONVERSATION withArgumentsInArray:args];
+    }));
+}
+
+- (void)updateMessages:(NSArray *)messages {
+    LCIM_OPEN_DATABASE(db, ({
+        for (AVIMMessage *message in messages) {
+            LCIM_OPEN_DATABASE(db, ({
+                NSArray *args = [self updationRecordForMessage:message];
+                [db executeUpdate:LCIM_SQL_UPDATE_MESSAGE_RCP withArgumentsInArray:args];
+            }));
+        }
+    }));
+}
+
+- (void)updateMessage:(NSArray *)message {
+    [self updateMessages:@[ message ]];
+}
+
+- (int64_t)latestReadTimestampFromPeer {
+   __block int64_t readTimestamp = 0;
+    LCIM_OPEN_DATABASE(db, ({
+        NSArray *args = @[
+                          self.conversationId,
+                          @(AVIMMessageStatusRead)
+                          ];
+        LCResultSet *result  = [db executeQuery:LCIM_SQL_SELECT_READ_TIMESTAMP withArgumentsInArray:args];
+        while ([result next]) {
+            readTimestamp = [result longLongIntForColumn:LCIM_FIELD_READ_TIMESTAMP];
+        }
+        
+        [result close];
+    }));
+    
+    return readTimestamp;
+}
+
+- (int64_t)latestDeliveredTimestampFromPeer {
+    __block int64_t deliveredTimestamp = 0;
+    LCIM_OPEN_DATABASE(db, ({
+        NSArray *args = @[
+                          self.conversationId,
+                          @(AVIMMessageStatusDelivered)
+                          ];
+        LCResultSet *result  = [db executeQuery:LCIM_SQL_SELECT_RECEIPT_TIMESTAMP withArgumentsInArray:args];
+        while ([result next]) {
+            deliveredTimestamp = [result longLongIntForColumn:LCIM_FIELD_RECEIPT_TIMESTAMP];
+        }
+        
+        [result close];
+    }));
+    
+    return deliveredTimestamp;
+}
+
+#pragma mark -
+#pragma mark - Private Methods
+
+- (NSNumber *)receiptTimestampForMessage:(AVIMMessage *)message {
+    return [NSNumber numberWithDouble:message.deliveredTimestamp];
+}
+
+- (NSNumber *)readTimestampForMessage:(AVIMMessage *)message {
+    return [NSNumber numberWithDouble:message.readTimestamp];
+}
+
+- (NSTimeInterval)currentTimestamp {
+    return [[NSDate date] timeIntervalSince1970] * 1000;
+}
+
+- (NSArray *)insertionRecordForMessage:(AVIMMessage *)message {
+    return @[
+             self.conversationId,
+             @(message.status),
+             [self receiptTimestampForMessage:message],
+             [self readTimestampForMessage:message],
+             ];
+}
+
+- (NSArray *)updationRecordForMessage:(AVIMMessage *)message {
+    return @[
+             [self receiptTimestampForMessage:message],
+             [self readTimestampForMessage:message],
+             @(message.status),
+             self.conversationId,
+             ];
+}
+
+@end

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageReceiptCacheStoreSQL.h
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageReceiptCacheStoreSQL.h
@@ -1,0 +1,64 @@
+//
+//  LCIMMessageReceiptCacheStoreSQL.h
+//  AVOS
+//
+//  Created by 陈宜龙 on 06/01/2017.
+//  Copyright © 2017 LeanCloud Inc. All rights reserved.
+//  用来存储对话中某人接收到的最新的回执情况：已读、已接收的时间戳
+
+#ifndef LCIMMessageReceiptCacheStoreSQL_h
+#define LCIMMessageReceiptCacheStoreSQL_h
+
+#define LCIM_TABLE_MESSAGE_RCP          @"message_rcp"
+
+#define LCIM_FIELD_CONVERSATION_ID      @"conversation_id"
+#define LCIM_FIELD_RECEIPT_TIMESTAMP    @"receipt_timestamp"
+#define LCIM_FIELD_READ_TIMESTAMP       @"read_timestamp"
+#define LCIM_FIELD_STATUS               @"status"
+
+#define LCIM_SQL_CREATE_MESSAGE_RCP_TABLE                                 \
+    @"CREATE TABLE IF NOT EXISTS " LCIM_TABLE_MESSAGE_RCP @" ("  \
+        LCIM_FIELD_CONVERSATION_ID                      @" TEXT, "    \
+        LCIM_FIELD_STATUS                               @" INTEGER, " \
+        LCIM_FIELD_RECEIPT_TIMESTAMP                    @" NUMBERIC, "\
+        LCIM_FIELD_READ_TIMESTAMP                       @" NUMBERIC, "\
+        @"PRIMARY KEY(" LCIM_FIELD_CONVERSATION_ID  @", " LCIM_FIELD_STATUS @") ON CONFLICT IGNORE"          \
+    @")"
+
+#define LCIM_SQL_INSERT_MESSAGE_RCP                                  \
+    @"INSERT OR REPLACE INTO " LCIM_TABLE_MESSAGE_RCP  @" ("          \
+        LCIM_FIELD_CONVERSATION_ID      @", "                    \
+        LCIM_FIELD_STATUS               @", "                    \
+        LCIM_FIELD_RECEIPT_TIMESTAMP    @", "                    \
+        LCIM_FIELD_READ_TIMESTAMP                                \
+    @") VALUES(?, ?, ?, ?)"
+
+#define LCIM_SQL_MESSAGE_RCP_WHERE_CLAUSE              \
+    @"WHERE " LCIM_FIELD_CONVERSATION_ID @" = ? "  \
+    @"AND " LCIM_FIELD_STATUS            @" = ?"
+
+#define LCIM_SQL_UPDATE_MESSAGE_RCP          \
+    @"UPDATE " LCIM_TABLE_MESSAGE_RCP    @" "\
+    @"SET "                                       \
+        LCIM_FIELD_RECEIPT_TIMESTAMP    @" = ?, " \
+        LCIM_FIELD_READ_TIMESTAMP       @" = ?, " \
+    LCIM_SQL_MESSAGE_RCP_WHERE_CLAUSE
+
+
+#define LCIM_SQL_SELECT_MESSAGE_RCP_BY_ID                 \
+    @"SELECT * FROM " LCIM_TABLE_MESSAGE_RCP @" "\
+    LCIM_SQL_MESSAGE_RCP_WHERE_CLAUSE
+
+#define LCIM_SQL_SELECT_READ_TIMESTAMP                                               \
+    @"SELECT " LCIM_FIELD_READ_TIMESTAMP @" FROM " LCIM_TABLE_MESSAGE_RCP @" "  \
+    LCIM_SQL_MESSAGE_RCP_WHERE_CLAUSE
+
+#define LCIM_SQL_SELECT_RECEIPT_TIMESTAMP                                               \
+    @"SELECT " LCIM_FIELD_RECEIPT_TIMESTAMP @" FROM " LCIM_TABLE_MESSAGE_RCP @" "  \
+    LCIM_SQL_MESSAGE_RCP_WHERE_CLAUSE
+
+#define LCIM_SQL_DELETE_CONVERSATION              \
+    @"DELETE FROM " LCIM_TABLE_MESSAGE_RCP @" "  \
+    @"WHERE " LCIM_FIELD_CONVERSATION_ID @" = ?"
+
+#endif /* LCIMMessageReceiptCacheStoreSQL_h */

--- a/AVOS/AVOSCloudIM/MessageCache/LCIMConversationCache.m
+++ b/AVOS/AVOSCloudIM/MessageCache/LCIMConversationCache.m
@@ -10,6 +10,7 @@
 #import "LCIMConversationCacheStore.h"
 #import "LCIMConversationQueryCacheStore.h"
 #import "AVIMConversation.h"
+#import "LCIMMessageReceiptCacheStore.h"
 
 @interface LCIMConversationCache ()
 
@@ -83,7 +84,12 @@
 }
 
 - (void)cleanAllExpiredConversations {
-    [self.cacheStore allExpiredConversations];
+    [self.cacheStore cleanAllExpiredConversations];
+    LCIMMessageReceiptCacheStore *messageReceiptCacheStore = [[LCIMMessageReceiptCacheStore alloc] initWithClientId:self.clientId];
+    NSArray<AVIMConversation *> *allExpiredConversations = [self.cacheStore allExpiredConversations];
+    for (AVIMConversation *conversation in allExpiredConversations) {
+        [messageReceiptCacheStore deleteConversation:conversation];
+    }
 }
 
 - (void)updateConversationForLastMessageAt:(NSDate *)lastMessageAt conversationId:(NSString *)conversationId {

--- a/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMApi.pbobjc.h
+++ b/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMApi.pbobjc.h
@@ -129,13 +129,13 @@ typedef GPB_ENUM(GPBApi_FieldNumber) {
  * Fetches the raw value of a @c GPBApi's @c syntax property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBApi_Syntax_RawValue(LCIMApi *message);
+int32_t LCIMApi_Syntax_RawValue(LCIMApi *message);
 /**
  * Sets the raw value of an @c GPBApi's @c syntax property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBApi_Syntax_RawValue(LCIMApi *message, int32_t value);
+void SetLCIMApi_Syntax_RawValue(LCIMApi *message, int32_t value);
 
 #pragma mark - GPBMethod
 
@@ -183,13 +183,13 @@ typedef GPB_ENUM(GPBMethod_FieldNumber) {
  * Fetches the raw value of a @c GPBMethod's @c syntax property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBMethod_Syntax_RawValue(LCIMMethod *message);
+int32_t LCIMMethod_Syntax_RawValue(LCIMMethod *message);
 /**
  * Sets the raw value of an @c GPBMethod's @c syntax property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBMethod_Syntax_RawValue(LCIMMethod *message, int32_t value);
+void SetLCIMMethod_Syntax_RawValue(LCIMMethod *message, int32_t value);
 
 #pragma mark - GPBMixin
 

--- a/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMApi.pbobjc.m
+++ b/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMApi.pbobjc.m
@@ -169,13 +169,13 @@ typedef struct LCIMApi__storage_ {
 
 @end
 
-int32_t GPBApi_Syntax_RawValue(LCIMApi *message) {
+int32_t LCIMApi_Syntax_RawValue(LCIMApi *message) {
   LCIMDescriptor *descriptor = [LCIMApi descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBApi_FieldNumber_Syntax];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBApi_Syntax_RawValue(LCIMApi *message, int32_t value) {
+void SetLCIMApi_Syntax_RawValue(LCIMApi *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMApi descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBApi_FieldNumber_Syntax];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
@@ -293,13 +293,13 @@ typedef struct LCIMMethod__storage_ {
 
 @end
 
-int32_t GPBMethod_Syntax_RawValue(LCIMMethod *message) {
+int32_t LCIMMethod_Syntax_RawValue(LCIMMethod *message) {
   LCIMDescriptor *descriptor = [LCIMMethod descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBMethod_FieldNumber_Syntax];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBMethod_Syntax_RawValue(LCIMMethod *message, int32_t value) {
+void SetLCIMMethod_Syntax_RawValue(LCIMMethod *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMMethod descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBMethod_FieldNumber_Syntax];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);

--- a/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMStruct.pbobjc.h
+++ b/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMStruct.pbobjc.h
@@ -159,18 +159,18 @@ typedef GPB_ENUM(GPBValue_Kind_OneOfCase) {
  * Fetches the raw value of a @c GPBValue's @c nullValue property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBValue_NullValue_RawValue(LCIMValue *message);
+int32_t LCIMValue_NullValue_RawValue(LCIMValue *message);
 /**
  * Sets the raw value of an @c GPBValue's @c nullValue property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBValue_NullValue_RawValue(LCIMValue *message, int32_t value);
+void SetLCIMValue_NullValue_RawValue(LCIMValue *message, int32_t value);
 
 /**
  * Clears whatever value was set for the oneof 'kind'.
  **/
-void GPBValue_ClearKindOneOfCase(LCIMValue *message);
+void LCIMValue_ClearKindOneOfCase(LCIMValue *message);
 
 #pragma mark - GPBListValue
 

--- a/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMStruct.pbobjc.m
+++ b/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMStruct.pbobjc.m
@@ -226,19 +226,19 @@ typedef struct LCIMValue__storage_ {
 
 @end
 
-int32_t GPBValue_NullValue_RawValue(LCIMValue *message) {
+int32_t LCIMValue_NullValue_RawValue(LCIMValue *message) {
   LCIMDescriptor *descriptor = [LCIMValue descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBValue_FieldNumber_NullValue];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBValue_NullValue_RawValue(LCIMValue *message, int32_t value) {
+void SetLCIMValue_NullValue_RawValue(LCIMValue *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMValue descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBValue_FieldNumber_NullValue];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
 }
 
-void GPBValue_ClearKindOneOfCase(LCIMValue *message) {
+void LCIMValue_ClearKindOneOfCase(LCIMValue *message) {
   LCIMDescriptor *descriptor = [message descriptor];
   LCIMOneofDescriptor *oneof = descriptor->oneofs_[0];
   LCIMMaybeClearOneof(message, oneof, -1, 0);

--- a/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMType.pbobjc.h
+++ b/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMType.pbobjc.h
@@ -230,13 +230,13 @@ typedef GPB_ENUM(GPBType_FieldNumber) {
  * Fetches the raw value of a @c GPBType's @c syntax property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBType_Syntax_RawValue(LCIMType *message);
+int32_t LCIMType_Syntax_RawValue(LCIMType *message);
 /**
  * Sets the raw value of an @c GPBType's @c syntax property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBType_Syntax_RawValue(LCIMType *message, int32_t value);
+void SetLCIMType_Syntax_RawValue(LCIMType *message, int32_t value);
 
 #pragma mark - GPBField
 
@@ -302,25 +302,25 @@ typedef GPB_ENUM(GPBField_FieldNumber) {
  * Fetches the raw value of a @c GPBField's @c kind property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBField_Kind_RawValue(LCIMField *message);
+int32_t LCIMField_Kind_RawValue(LCIMField *message);
 /**
  * Sets the raw value of an @c GPBField's @c kind property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBField_Kind_RawValue(LCIMField *message, int32_t value);
+void SetLCIMField_Kind_RawValue(LCIMField *message, int32_t value);
 
 /**
  * Fetches the raw value of a @c GPBField's @c cardinality property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBField_Cardinality_RawValue(LCIMField *message);
+int32_t LCIMField_Cardinality_RawValue(LCIMField *message);
 /**
  * Sets the raw value of an @c GPBField's @c cardinality property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBField_Cardinality_RawValue(LCIMField *message, int32_t value);
+void SetLCIMField_Cardinality_RawValue(LCIMField *message, int32_t value);
 
 #pragma mark - GPBEnum
 
@@ -364,13 +364,13 @@ typedef GPB_ENUM(GPBEnum_FieldNumber) {
  * Fetches the raw value of a @c GPBEnum's @c syntax property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBEnum_Syntax_RawValue(LCIMEnum *message);
+int32_t LCIMEnum_Syntax_RawValue(LCIMEnum *message);
 /**
  * Sets the raw value of an @c GPBEnum's @c syntax property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBEnum_Syntax_RawValue(LCIMEnum *message, int32_t value);
+void SetLCIMEnum_Syntax_RawValue(LCIMEnum *message, int32_t value);
 
 #pragma mark - GPBEnumValue
 

--- a/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMType.pbobjc.m
+++ b/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMType.pbobjc.m
@@ -182,13 +182,13 @@ typedef struct GPBType__storage_ {
 
 @end
 
-int32_t GPBType_Syntax_RawValue(LCIMType *message) {
+int32_t LCIMType_Syntax_RawValue(LCIMType *message) {
   LCIMDescriptor *descriptor = [LCIMType descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBType_FieldNumber_Syntax];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBType_Syntax_RawValue(LCIMType *message, int32_t value) {
+void SetLCIMType_Syntax_RawValue(LCIMType *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMType descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBType_FieldNumber_Syntax];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
@@ -340,25 +340,25 @@ typedef struct LCIMField__storage_ {
 
 @end
 
-int32_t GPBField_Kind_RawValue(LCIMField *message) {
+int32_t LCIMField_Kind_RawValue(LCIMField *message) {
   LCIMDescriptor *descriptor = [LCIMField descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBField_FieldNumber_Kind];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBField_Kind_RawValue(LCIMField *message, int32_t value) {
+void SetLCIMField_Kind_RawValue(LCIMField *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMField descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBField_FieldNumber_Kind];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
 }
 
-int32_t GPBField_Cardinality_RawValue(LCIMField *message) {
+int32_t LCIMField_Cardinality_RawValue(LCIMField *message) {
   LCIMDescriptor *descriptor = [LCIMField descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBField_FieldNumber_Cardinality];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBField_Cardinality_RawValue(LCIMField *message, int32_t value) {
+void SetLCIMField_Cardinality_RawValue(LCIMField *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMField descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBField_FieldNumber_Cardinality];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
@@ -564,13 +564,13 @@ typedef struct LCIMEnum__storage_ {
 
 @end
 
-int32_t GPBEnum_Syntax_RawValue(LCIMEnum *message) {
+int32_t LCIMEnum_Syntax_RawValue(LCIMEnum *message) {
   LCIMDescriptor *descriptor = [LCIMEnum descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBEnum_FieldNumber_Syntax];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBEnum_Syntax_RawValue(LCIMEnum *message, int32_t value) {
+void SetLCIMEnum_Syntax_RawValue(LCIMEnum *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMEnum descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBEnum_FieldNumber_Syntax];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);

--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.h
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.h
@@ -22,8 +22,11 @@
 
 FOUNDATION_EXPORT NSString *const AVIMProtocolJSON1;
 FOUNDATION_EXPORT NSString *const AVIMProtocolJSON2;
+FOUNDATION_EXPORT NSString *const AVIMProtocolJSON3;
+
 FOUNDATION_EXPORT NSString *const AVIMProtocolPROTOBUF1;
 FOUNDATION_EXPORT NSString *const AVIMProtocolPROTOBUF2;
+FOUNDATION_EXPORT NSString *const AVIMProtocolPROTOBUF3;
 
 @interface AVIMWebSocketWrapper : NSObject
 

--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -630,7 +630,7 @@ SecCertificateRef LCGetCertificateFromBase64String(NSString *base64);
     NSDictionary *userOptions = [AVIMClient userOptions];
 
     if ([userOptions[AVIMUserOptionUseUnread] boolValue]) {
-        [protocols addObject:AVIMProtocolPROTOBUF2];
+        [protocols addObject:AVIMProtocolPROTOBUF3];
     } else {
         [protocols addObject:AVIMProtocolPROTOBUF1];
     }

--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -441,8 +441,7 @@ NSString *const AVIMProtocolPROTOBUF3 = @"lc.protobuf.3";
             if (self.security) {
                 parameters[@"secure"] = @"1";
             }
-            //FIXME:这个是需要删除的，review的时候提醒下我
-            parameters[@"server"] = @"rtm51";
+
             /* Back door for user to connect to puppet environment. */
             if (getenv("LC_IM_PUPPET_ENABLED") && getenv("SIMULATOR_UDID")) {
                 parameters[@"debug"] = @"true";

--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -441,7 +441,8 @@ NSString *const AVIMProtocolPROTOBUF3 = @"lc.protobuf.3";
             if (self.security) {
                 parameters[@"secure"] = @"1";
             }
-
+            //FIXME:这个是需要删除的，review的时候提醒下我
+            parameters[@"server"] = @"rtm51";
             /* Back door for user to connect to puppet environment. */
             if (getenv("LC_IM_PUPPET_ENABLED") && getenv("SIMULATOR_UDID")) {
                 parameters[@"debug"] = @"true";

--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -63,6 +63,10 @@ NSString *const AVIMProtocolJSON2 = @"lc.json.2";
 NSString *const AVIMProtocolMessagePack2 = @"lc.msgpack.2";
 NSString *const AVIMProtocolPROTOBUF2 = @"lc.protobuf.2";
 
+NSString *const AVIMProtocolJSON3 = @"lc.json.3";
+NSString *const AVIMProtocolMessagePack3 = @"lc.msgpack.3";
+NSString *const AVIMProtocolPROTOBUF3 = @"lc.protobuf.3";
+
 @interface AVIMCommandCarrier : NSObject
 @property(nonatomic, strong) AVIMGenericCommand *command;
 @property(nonatomic)NSTimeInterval timestamp;

--- a/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
+++ b/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
@@ -256,6 +256,17 @@
     WAIT;
 }
 
+- (void)testMarkAsRead {
+    __weak AVIMConversation *conversation = self.conversation;
+    [conversation queryMessagesFromServerWithLimit:10 callback:^(NSArray * _Nullable objects, NSError * _Nullable error) {
+        XCTAssertTrue(objects.count > 0);
+        AVIMMessage *message = [objects lastObject];
+        [conversation markAsReadInBackgroundForMessage:message];
+        NOTIFY
+    }];
+    WAIT;
+}
+
 - (void)testConversationMembersUpdate {
     AVIMConversation *conversation = [self conversationForUpdate];
     __weak typeof(conversation) weakConversation = conversation;

--- a/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
+++ b/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
@@ -261,7 +261,7 @@
     [conversation queryMessagesFromServerWithLimit:10 callback:^(NSArray * _Nullable objects, NSError * _Nullable error) {
         XCTAssertTrue(objects.count > 0);
         AVIMMessage *message = [objects lastObject];
-        [conversation markAsReadInBackgroundForMessage:message];
+        [conversation markAsReadInBackgroundForLastMessage];
         NOTIFY
     }];
     WAIT;

--- a/AVOS/AVOSCloudTests/LogicTests/AVInstallationTest.m
+++ b/AVOS/AVOSCloudTests/LogicTests/AVInstallationTest.m
@@ -68,6 +68,13 @@
     NSError *error;
     [[AVInstallation currentInstallation] delete:&error];
     XCTAssertNil(error);
+    
+    [[AVInstallation currentInstallation] removeObjectForKey:@"name"];
+    [[AVInstallation currentInstallation] save:&error];
+    XCTAssertNil(error);
+    id object = [[AVInstallation currentInstallation]  objectForKey:@"name"];
+    [[AVInstallation currentInstallation] fetch:&error];
+    XCTAssertNil(object);
 }
 
 // https://ticket.leancloud.cn/tickets/8487

--- a/proto/messages.proto.orig
+++ b/proto/messages.proto.orig
@@ -57,6 +57,9 @@ enum OpType {
   updated = 46;
   mute = 47;
   unmute = 48;
+  status = 49;
+  members = 50;
+  max_read = 51;
 
   // room
   join = 80;
@@ -125,6 +128,7 @@ message SessionCommand {
   optional string reason = 13;
   optional string deviceToken = 14;
   optional bool sp = 15;
+  optional string detail = 16;
 }
 
 message ErrorCommand {
@@ -148,6 +152,7 @@ message DirectCommand {
   optional bool transient = 13;
   optional string dt = 14;
   optional string roomId = 15;
+  optional string pushData = 16;
 }
 
 message AckCommand {
@@ -185,6 +190,15 @@ message ConvCommand {
   optional string n = 14;
   optional string s = 15;
 
+  optional bool statusSub = 16;
+  optional bool statusPub = 17;
+  optional int32 statusTTL = 18;
+
+  //repeated string members = 19;
+  optional string targetClientId = 20;
+  optional int64 maxReadTimestamp = 21;
+  optional int64 maxAckTimestamp = 22;
+  
   optional JsonObjectMessage results = 100;
   optional JsonObjectMessage where = 101;
   optional JsonObjectMessage attr = 103;
@@ -210,6 +224,7 @@ message LogsCommand {
   optional string mid = 7;
   optional string checksum = 8;
   optional bool stored = 9;
+  optional bool reversed = 10;
 
   repeated LogItem logs = 105;
 }
@@ -218,6 +233,7 @@ message RcpCommand {
   optional string id = 1;
   optional string cid = 2;
   optional int64 t = 3;
+  optional bool read = 4;
 }
 
 message ReadTuple {
@@ -235,6 +251,7 @@ message ReadCommand {
 message PresenceCommand {
   optional StatusType status = 1;
   repeated string sessionPeerIds = 2;
+  optional string cid = 3;
 }
 
 message ReportCommand {
@@ -251,6 +268,7 @@ message GenericCommand {
   optional string peerId = 4;
   optional int32 i = 5;
   optional string installationId = 6;
+  optional int32 priority = 7;
 
   optional LoginCommand loginMessage = 100;
   optional DataCommand dataMessage = 101;

--- a/proto/messages.proto.orig
+++ b/proto/messages.proto.orig
@@ -246,6 +246,7 @@ message ReadCommand {
   optional string cid = 1;
   repeated string cids = 2;
   repeated ReadTuple convs = 3;
+  optional bool triggerReceipt = 4;
 }
 
 message PresenceCommand {

--- a/proto/messages.proto.orig
+++ b/proto/messages.proto.orig
@@ -93,6 +93,8 @@ message UnreadTuple {
   required int32 unread = 2;
   optional string mid = 3;
   optional int64 timestamp = 4;
+  optional string from = 5;
+  optional string data = 6;
 }
 
 message LogItem {
@@ -101,6 +103,7 @@ message LogItem {
   optional int64 timestamp = 3;
   optional string msgId = 4;
   optional int64 ackAt = 5;
+  optional int64 readAt = 6;
 }
 
 message LoginCommand {
@@ -129,6 +132,7 @@ message SessionCommand {
   optional string deviceToken = 14;
   optional bool sp = 15;
   optional string detail = 16;
+  optional int64 lastUnreadNotifTime = 17;
 }
 
 message ErrorCommand {
@@ -153,6 +157,7 @@ message DirectCommand {
   optional string dt = 14;
   optional string roomId = 15;
   optional string pushData = 16;
+  optional bool will = 17;
 }
 
 message AckCommand {
@@ -171,6 +176,7 @@ message AckCommand {
 
 message UnreadCommand {
   repeated UnreadTuple convs = 1;
+  optional int64 notifTime = 2;
 }
 
 message ConvCommand {
@@ -194,11 +200,10 @@ message ConvCommand {
   optional bool statusPub = 17;
   optional int32 statusTTL = 18;
 
-  //repeated string members = 19;
   optional string targetClientId = 20;
   optional int64 maxReadTimestamp = 21;
   optional int64 maxAckTimestamp = 22;
-  
+
   optional JsonObjectMessage results = 100;
   optional JsonObjectMessage where = 101;
   optional JsonObjectMessage attr = 103;
@@ -246,7 +251,6 @@ message ReadCommand {
   optional string cid = 1;
   repeated string cids = 2;
   repeated ReadTuple convs = 3;
-  optional bool triggerReceipt = 4;
 }
 
 message PresenceCommand {


### PR DESCRIPTION
* [ ] 文档：https://github.com/leancloud/docs/pull/1723
* [ ]  文档特别说明：之前废弃的针对conversation的markAsRead不能简单地替换为针对Message的markAsRead，调用时机的策略也需要修正下。
* [x] 本地维护RCP表的功能，该表用来存储对话中某人接收到的最新的回执情况：已读、已接收的时间戳。（还差一个服务端查询更新，用来用户第一个进入对话时，主动从服务端拉取最新的RCP信息，更新本地表。见下一条。）
* [x] 针对离线的rcp消息，服务端需要提供一个获取对话中某人接收到的最新的回执情况：已读、已接收的时间戳，客户端按需查询，进行未读标记。
* [x] 从网络查询到的历史记录，在存入数据库之前，总是与本地RCP表进行对比，更新status状态。
* [x] 接收到RCP消息后，更新所有相关更早期的消息在缓存（内存缓存、本地缓存）中状态。
* [x]  清除本地缓存API
