### PR TITLE
only update customAttributes for conversation update

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMConversation.m
+++ b/AVOS/AVOSCloudIM/AVIMConversation.m
@@ -292,7 +292,8 @@
 - (void)updateWithCallback:(AVIMBooleanResultBlock)callback {
     dispatch_async([AVIMClient imClientQueue], ^{
         NSDictionary *updateBuilderDataSource = [self.mutableAttributes copy];
-        AVIMGenericCommand *genericCommand = [self generateGenericCommandWithAttributes:updateBuilderDataSource];
+        NSDictionary *customAttributes = [[self class] filterCustomAttributesFromDictionary:updateBuilderDataSource];
+        AVIMGenericCommand *genericCommand = [self generateGenericCommandWithAttributes:customAttributes];
         [genericCommand setCallback:^(AVIMGenericCommand *outCommand, AVIMGenericCommand *inCommand, NSError *error) {
             if (!error) {
                 [self updateAttributesWithUpdateBuilderDataSource:updateBuilderDataSource customAttributes:updateBuilderDataSource];
@@ -687,7 +688,7 @@
     //新版本中也可能产生同时含有attr字段，以及和attr字段同级的其他自定义属性
     //同时含有attr和同一个层级的自定义属性，如果包含同一个自定义名称，则以新形式的自定义属性为准。
     NSMutableDictionary *campatibleCustomAttributes = [attr mutableCopy];
-    [campatibleCustomAttributes addEntriesFromDictionary:dictionary];
+    [campatibleCustomAttributes addEntriesFromDictionary:customAttributes];
     return [campatibleCustomAttributes copy];
 }
 

--- a/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
+++ b/AVOS/AVOSCloudIMTests/AVIMConversationTest.m
@@ -94,7 +94,6 @@
     query2.limit = 10;
     [query2 whereKey:@"sys" equalTo:@(YES)];
    
-    
     __block NSUInteger query1Result = 0;
     __block NSUInteger query2Result = 0;
     [query1 findConversationsWithCallback:^(NSArray * _Nullable objects, NSError * _Nullable error) {
@@ -139,7 +138,9 @@
 }
 
 - (void)testConversationGetterAndSetter {
-    AVIMConversation *conversation = [self conversationForTest];
+    AVIMConversation *conversation = [self conversationForUpdate];
+    NSUInteger membersCount = conversation.members.count;
+    BOOL muted = conversation.muted;
     NSNumber *number = @(arc4random());
     NSString *name = [number stringValue];
     [conversation setObject:number forKey:@"number"];
@@ -149,6 +150,9 @@
         XCTAssertNil(error);
         XCTAssertEqualObjects(conversation.name, name);
         XCTAssertEqualObjects([conversation objectForKey:@"number"], number);
+        XCTAssertEqualObjects(@(conversation.members.count), @(membersCount));
+        XCTAssertEqualObjects(@(conversation.muted), @(muted));
+
         NOTIFY;
     }];
     WAIT;
@@ -157,7 +161,8 @@
 //FIXME:TEST FAILED ==> ALL XCTAssertNil FAILED
 //AVIMConvCommand should has cid
 - (void)testUpdateConversation {
-    AVIMConversation *conversation = [self conversationForTest];
+    AVIMConversation *conversation = [self conversationForUpdate];
+
     AVIMConversationUpdateBuilder *builder = [[AVIMConversationUpdateBuilder alloc] init];
     NSString *name = NSStringFromSelector(_cmd);
     builder.name = name;
@@ -182,7 +187,7 @@
 }
 
 - (void)testConversationMembersUpdate {
-    __weak AVIMConversation *conversation = [self conversationForTest];
+    __weak AVIMConversation *conversation = [self conversationForUpdate];
     [conversation addMembersWithClientIds:@[ AVIM_TEST_ClinetID_Peer_1 ] callback:^(BOOL succeeded, NSError *error) {
         XCTAssertNil(error);
         XCTAssertTrue([conversation.members containsObject:AVIM_TEST_ClinetID_Peer_1]);

--- a/AVOS/AVOSCloudIMTests/AVIMTestBase.h
+++ b/AVOS/AVOSCloudIMTests/AVIMTestBase.h
@@ -16,6 +16,8 @@
 - (AVIMConversation *)queryConversationById:(NSString *)convid;
 
 - (AVIMConversation *)conversationForTest;
+- (AVIMConversation *)conversationForUpdate;
+
 - (AVIMConversation *)transientConversationForTest;
 
 @end

--- a/AVOS/AVOSCloudIMTests/AVIMTestBase.m
+++ b/AVOS/AVOSCloudIMTests/AVIMTestBase.m
@@ -42,6 +42,18 @@
     return [self conversationForTestWithOption:AVIMConversationOptionNone];
 }
 
+- (AVIMConversation *)conversationForUpdate {
+    __block AVIMConversation *conversation = nil;
+    AVIMConversationQuery *query1 = [[AVIMClient defaultClient] conversationQuery];
+    [query1 findConversationsWithCallback:^(NSArray * _Nullable objects, NSError * _Nullable error) {
+        XCTAssertTrue(objects.count >0 );
+        conversation = objects[0];
+        NOTIFY;
+    }];
+    WAIT;
+    return conversation;
+}
+
 - (AVIMConversation *)transientConversationForTest {
     return [self conversationForTestWithOption:AVIMConversationOptionTransient];
 }


### PR DESCRIPTION
@leancloud/ios-group  conversation的update方法，只将自定义字段上传。

之前的conversation的update方法是全量更新，主要的问题在于：

1. 没有必要，数据量过大，尤其是SDK对command有5k的限制，members字段容易导致超出
2. 更新时，如果有members更新，容易被update方法覆盖。

