### PR TITLE
Support error handing for Swift

### DIFF
--- a/AVOS/AVOSCloud/AVOSCloud.h
+++ b/AVOS/AVOSCloud/AVOSCloud.h
@@ -286,6 +286,12 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSDate *)getServerDate:(NSError **)error;
 
 /*!
+ An alias of `+[AVOSCloud getServerDate:]` methods that supports Swift exception.
+ @seealso `+[AVPush getServerDate:]`
+ */
++ (nullable NSDate *)getServerDateAndThrowsWithError:(NSError **)error;
+
+/*!
  * 异步地获取服务端时间。
  * @param block 回调结果。
  */

--- a/AVOS/AVOSCloud/AVOSCloud.m
+++ b/AVOS/AVOSCloud/AVOSCloud.m
@@ -388,6 +388,10 @@ static AVLogLevel avlogLevel = AVLogLevelDefault;
     return date;
 }
 
++ (NSDate *)getServerDateAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self getServerDate:error];
+}
+
 + (void)getServerDateWithBlock:(void (^)(NSDate *, NSError *))block {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSError *error = nil;

--- a/AVOS/AVOSCloud/File/AVFile.h
+++ b/AVOS/AVOSCloud/File/AVFile.h
@@ -114,6 +114,12 @@ The name of the file.
 - (BOOL)save:(NSError **)error;
 
 /*!
+ An alias of `-[AVFile save:]` methods that supports Swift exception.
+ @seealso `-[AVFile save:]`
+ */
+- (BOOL)saveAndThrowsWithError:(NSError **)error;
+
+/*!
  Saves the file asynchronously.
  @return whether the save succeeded.
  */

--- a/AVOS/AVOSCloud/File/AVFile.m
+++ b/AVOS/AVOSCloud/File/AVFile.m
@@ -158,6 +158,10 @@ static NSMutableDictionary *downloadingMap = nil;
     return theResult;
 }
 
+- (BOOL)saveAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self save:error];
+}
+
 - (void)saveInBackground
 {
     [self saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {

--- a/AVOS/AVOSCloud/Object/AVObject.h
+++ b/AVOS/AVOSCloud/Object/AVObject.h
@@ -237,6 +237,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)save:(NSError **)error;
 
 /*!
+ An alias of `-[AVObject save:]` methods that supports Swift exception.
+ @seealso `-[AVObject save:]`
+ */
+- (BOOL)saveAndThrowsWithError:(NSError **)error;
+
+/*!
  * Saves the AVObject with option and sets an error if it occurs.
  * @param option Option for current save.
  * @param error  A pointer to an NSError that will be set if necessary.
@@ -394,6 +400,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)refresh:(NSError **)error;
 
 /*!
+ An alias of `-[AVObject refresh:]` methods that supports Swift exception.
+ @seealso `-[AVObject refresh:]`
+ */
+- (BOOL)refreshAndThrowsWithError:(NSError **)error;
+
+/*!
  Refreshes the AVObject asynchronously and executes the given callback block.
  @param block The block to execute. The block should have the following argument signature: (AVObject *object, NSError *error)
  */
@@ -429,6 +441,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)fetch:(NSError **)error;
 
 /*!
+ An alias of `-[AVObject fetch:]` methods that supports Swift exception.
+ @seealso `-[AVObject fetch:]`
+ */
+- (BOOL)fetchAndThrowsWithError:(NSError **)error;
+
+/*!
  Fetches the AVObject with the current data and specified keys from the server and sets an error if it occurs.
  @param keys Pointer to an NSArray that contains objects specified by the keys want to fetch.
  */
@@ -453,6 +471,12 @@ NS_ASSUME_NONNULL_BEGIN
  @param error Pointer to an NSError that will be set if necessary.
  */
 - (AVObject *)fetchIfNeeded:(NSError **)error;
+
+/*!
+ An alias of `-[AVObject fetchIfNeeded:]` methods that supports Swift exception.
+ @seealso `-[AVObject fetchIfNeeded:]`
+ */
+- (AVObject *)fetchIfNeededAndThrowsWithError:(NSError **)error;
 
 /*!
  Fetches the AVObject's data from the server if isDataAvailable is false.
@@ -586,6 +610,12 @@ NS_ASSUME_NONNULL_BEGIN
  @return whether the delete succeeded.
  */
 - (BOOL)delete:(NSError **)error;
+
+/*!
+ An alias of `-[AVObject delete:]` methods that supports Swift exception.
+ @seealso `-[AVObject delete:]`
+ */
+- (BOOL)deleteAndThrowsWithError:(NSError **)error;
 
 /*!
  Deletes the AVObject asynchronously.

--- a/AVOS/AVOSCloud/Object/AVObject.m
+++ b/AVOS/AVOSCloud/Object/AVObject.m
@@ -675,6 +675,10 @@ BOOL requests_contain_request(NSArray *requests, NSDictionary *request) {
     return [self saveWithOption:nil error:error];
 }
 
+- (BOOL)saveAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self save:error];
+}
+
 - (BOOL)saveWithOption:(AVSaveOption *)option
                  error:(NSError *__autoreleasing *)error
 {
@@ -1355,6 +1359,10 @@ BOOL requests_contain_request(NSArray *requests, NSDictionary *request) {
     return [self refreshWithBlock:NULL keys:nil waitUntilDone:YES error:error];
 }
 
+- (BOOL)refreshAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self refresh:error];
+}
+
 - (void)refreshInBackgroundWithBlock:(AVObjectResultBlock)block {
     [self refreshWithBlock:block keys:nil waitUntilDone:NO error:NULL];
 }
@@ -1445,6 +1453,10 @@ BOOL requests_contain_request(NSArray *requests, NSDictionary *request) {
     return [self fetchWithKeys:nil error:error];
 }
 
+- (BOOL)fetchAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self fetch:error];
+}
+
 - (void)fetchWithKeys:(NSArray *)keys {
     [self fetchWithKeys:keys error:nil];
 }
@@ -1472,6 +1484,10 @@ BOOL requests_contain_request(NSArray *requests, NSDictionary *request) {
 - (AVObject *)fetchIfNeeded:(NSError **)error
 {
     return [self fetchIfNeededWithKeys:nil error:error];
+}
+
+- (AVObject *)fetchIfNeededAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self fetchIfNeeded:error];
 }
 
 - (AVObject *)fetchIfNeededWithKeys:(NSArray *)keys {
@@ -1702,6 +1718,10 @@ BOOL requests_contain_request(NSArray *requests, NSDictionary *request) {
         *error = blockError;
     }
     return blockError == nil;
+}
+
+- (BOOL)deleteAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self delete:error];
 }
 
 - (void)deleteInBackground

--- a/AVOS/AVOSCloud/Push/AVPush.h
+++ b/AVOS/AVOSCloud/Push/AVPush.h
@@ -232,6 +232,12 @@ extern NSString *const kAVPushTargetPlatformWindowsPhone;
 - (BOOL)sendPush:(NSError **)error;
 
 /*!
+ An alias of `-[AVPush sendPush:]` methods that supports Swift exception.
+ @seealso `-[AVPush sendPush:]`
+ */
+- (BOOL)sendPushAndThrowsWithError:(NSError **)error;
+
+/*!
  Asynchronously send this push message.
  */
 - (void)sendPushInBackground;
@@ -334,6 +340,12 @@ extern NSString *const kAVPushTargetPlatformWindowsPhone;
  @return an NSSet containing all the channel names this device is subscribed to.
  */
 + (nullable NSSet *)getSubscribedChannels:(NSError **)error;
+
+/*!
+ An alias of `-[AVPush getSubscribedChannels:]` methods that supports Swift exception.
+ @seealso `-[AVPush getSubscribedChannels:]`
+ */
++ (nullable NSSet *)getSubscribedChannelsAndThrowsWithError:(NSError **)error;
 
 /*!
  Get all the channels that this device is subscribed to.

--- a/AVOS/AVOSCloud/Push/AVPush.m
+++ b/AVOS/AVOSCloud/Push/AVPush.m
@@ -260,6 +260,10 @@ NSString *const kAVPushTargetPlatformWindowsPhone = @"wp";
     return [AVPush sendPushMessage:self wait:YES block:^(BOOL succeeded, NSError *error) {} error:error];
 }
 
+- (BOOL)sendPushAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self sendPush:error];
+}
+
 - (void)sendPushInBackground
 {
     [AVPush sendPushMessage:self wait:NO block:^(BOOL succeeded, NSError *error) {} error:nil];
@@ -417,6 +421,10 @@ NSString *const kAVPushTargetPlatformWindowsPhone = @"wp";
 {
     return [AVPush getSubscribedChannelsWithBlock:^(NSSet *channels, NSError *error) {
     } wait:YES error:error];
+}
+
++ (NSSet *)getSubscribedChannelsAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self getSubscribedChannels:error];
 }
 
 + (void)getSubscribedChannelsInBackgroundWithBlock:(AVSetResultBlock)block

--- a/AVOS/AVOSCloud/Query/AVQuery.h
+++ b/AVOS/AVOSCloud/Query/AVQuery.h
@@ -540,6 +540,12 @@ typedef NS_ENUM(NSInteger, AVQueryDistanceUnit) {
 - (nullable NSArray *)findObjects:(NSError **)error;
 
 /*!
+ An alias of `-[AVQuery findObjects:]` methods that supports Swift exception.
+ @seealso `-[AVQuery findObjects:]`
+ */
+- (nullable NSArray *)findObjectsAndThrowsWithError:(NSError **)error;
+
+/*!
  Finds objects asynchronously and calls the given block with the results.
  @param block The block to execute. The block should have the following argument signature:(NSArray *objects, NSError *error) 
  */
@@ -582,6 +588,12 @@ typedef NS_ENUM(NSInteger, AVQueryDistanceUnit) {
 - (nullable AVObject *)getFirstObject:(NSError **)error;
 
 /*!
+ An alias of `-[AVQuery getFirstObject:]` methods that supports Swift exception.
+ @seealso `-[AVQuery getFirstObject:]`
+ */
+- (nullable AVObject *)getFirstObjectAndThrowsWithError:(NSError **)error;
+
+/*!
  Gets an object asynchronously and calls the given block with the result.
  
  This mutates the AVQuery.
@@ -617,6 +629,12 @@ typedef NS_ENUM(NSInteger, AVQueryDistanceUnit) {
  @return the number of AVObjects that match the query, or -1 if there is an error.
  */
 - (NSInteger)countObjects:(NSError **)error;
+
+/*!
+ An alias of `-[AVQuery countObjects:]` methods that supports Swift exception.
+ @seealso `-[AVQuery countObjects:]`
+ */
+- (NSInteger)countObjectsAndThrowsWithError:(NSError **)error;
 
 /*!
  Counts objects asynchronously and calls the given block with the counts.

--- a/AVOS/AVOSCloud/Query/AVQuery.m
+++ b/AVOS/AVOSCloud/Query/AVQuery.m
@@ -713,6 +713,10 @@ NSString *LCStringFromDistanceUnit(AVQueryDistanceUnit unit) {
     return [self findObjectsWithBlock:NULL waitUntilDone:YES error:error];
 }
 
+- (NSArray *)findObjectsAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self findObjects:error];
+}
+
 -(void)queryWithBlock:(NSString *)path
            parameters:(NSDictionary *)parameters
                 block:(AVArrayResultBlock)resultBlock
@@ -841,6 +845,10 @@ NSString *LCStringFromDistanceUnit(AVQueryDistanceUnit unit) {
     return [self getFirstObjectWithBlock:NULL waitUntilDone:YES error:error];
 }
 
+- (AVObject *)getFirstObjectAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self getFirstObject:error];
+}
+
 /*!
  Gets an object asynchronously and calls the given block with the result.
 
@@ -938,6 +946,10 @@ NSString *LCStringFromDistanceUnit(AVQueryDistanceUnit unit) {
 - (NSInteger)countObjects:(NSError **)error
 {
     return [self countObjectsWithBlock:NULL waitUntilDone:YES error:error];
+}
+
+- (NSInteger)countObjectsAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self countObjects:error];
 }
 
 /*!

--- a/AVOS/AVOSCloud/Search/AVSearchQuery.h
+++ b/AVOS/AVOSCloud/Search/AVSearchQuery.h
@@ -94,6 +94,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSArray *)findObjects:(NSError **)error;
 
 /*!
+ An alias of `-[AVSearchQuery findObjects:]` methods that supports Swift exception.
+ @seealso `-[AVSearchQuery findObjects:]`
+ */
+- (nullable NSArray *)findObjectsAndThrowsWithError:(NSError **)error;
+
+/*!
  *  异步获取搜索结果，并回调block
  *  @param block 需要有这样的方法签名 (NSArray *objects, NSError *error)
  */

--- a/AVOS/AVOSCloud/Search/AVSearchQuery.m
+++ b/AVOS/AVOSCloud/Search/AVSearchQuery.m
@@ -58,6 +58,10 @@
     return [self findObjectsWithBlock:NULL waitUntilDone:YES error:error];
 }
 
+- (NSArray *)findObjectsAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self findObjects:error];
+}
+
 - (void)findInBackground:(AVArrayResultBlock)resultBlock {
     [self findObjectsWithBlock:resultBlock waitUntilDone:NO error:NULL];
 }

--- a/AVOS/AVOSCloud/User/AVUser.h
+++ b/AVOS/AVOSCloud/User/AVUser.h
@@ -132,6 +132,12 @@ A LeanCloud Framework User Object that is a local representation of a user persi
 - (nullable NSArray<AVRole *> *)getRoles:(NSError **)error;
 
 /*!
+ An alias of `-[AVUser getRolesAndThrowsWithError:]` methods that supports Swift exception.
+ @seealso `-[AVUser getRolesAndThrowsWithError:]`
+ */
+- (nullable NSArray<AVRole *> *)getRolesAndThrowsWithError:(NSError **)error;
+
+/*!
  Asynchronously get roles which current user belongs to.
 
  @param block The callback for request.
@@ -144,6 +150,12 @@ A LeanCloud Framework User Object that is a local representation of a user persi
  @return whether the sign up was successful.
  */
 - (BOOL)signUp:(NSError **)error;
+
+/*!
+ An alias of `-[AVUser signUp:]` methods that supports Swift exception.
+ @seealso `-[AVUser signUp:]`
+ */
+- (BOOL)signUpAndThrowsWithError:(NSError **)error;
 
 /*!
  Signs up the user asynchronously. Make sure that password and username are set. This will also enforce that the username isn't already taken.

--- a/AVOS/AVOSCloud/User/AVUser.m
+++ b/AVOS/AVOSCloud/User/AVUser.m
@@ -135,6 +135,10 @@ static BOOL enableAutomatic = NO;
     return [query findObjects:error];
 }
 
+- (NSArray<AVRole *> *)getRolesAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self getRoles:error];
+}
+
 - (void)getRolesInBackgroundWithBlock:(void (^)(NSArray<AVRole *> * _Nullable, NSError * _Nullable))block {
     [AVUtils asynchronizeTask:^{
         NSError *error = nil;
@@ -198,6 +202,10 @@ static BOOL enableAutomatic = NO;
 - (BOOL)signUp:(NSError *__autoreleasing *)error
 {
     return [self saveWithOption:nil eventually:NO verifyBefore:NO error:error];
+}
+
+- (BOOL)signUpAndThrowsWithError:(NSError * _Nullable __autoreleasing *)error {
+    return [self signUp:error];
 }
 
 - (void)signUpInBackground


### PR DESCRIPTION
让 API 支持 Swift 异常处理。由于所有方法都有个同名的、不带 error 参数的版本，不能简单地加 `WithError` 后缀。这里使用了 `AndThrowsWithError` 后缀。在 Swift 中的使用如下：

```swift
do {
    _ = try query.findObjectsAndThrows()
} catch {
    print(error)
}
```

@leancloud/tech-support @leancloud/ios-group