### PR TITLE
Avoid session token to be lost

### DIFF
--- a/AVOS/AVOSCloud/User/AVUser.m
+++ b/AVOS/AVOSCloud/User/AVUser.m
@@ -875,6 +875,19 @@ static BOOL enableAutomatic = NO;
 }
 
 #pragma mark - Override from AVObject
+
+/**
+ Avoid session token to be removed after fetching or refreshing.
+ */
+- (void)removeLocalData {
+    NSString *sessionToken = self.localData[@"sessionToken"];
+
+    [super removeLocalData];
+
+    if (sessionToken)
+        self.localData[@"sessionToken"] = sessionToken;
+}
+
 -(NSMutableDictionary *)postData
 {
     // TO BE REMOVED

--- a/AVOS/AVOSCloudTests/LogicTests/AVUserTest.m
+++ b/AVOS/AVOSCloudTests/LogicTests/AVUserTest.m
@@ -422,4 +422,10 @@
     [user delete];
 }
 
+- (void)testSessionToken {
+    AVUser *user = [self signUpRandomUser];
+    XCTAssertTrue([user fetch]);
+    XCTAssertNotNil(user.sessionToken);
+}
+
 @end


### PR DESCRIPTION
防止 AVUser 刷新后，session token 丢失的问题，关联 issue #127。 @leancloud/ios-group @nicecui