### PR TITLE
Remove start methods for analytics

### DIFF
--- a/AVOS/AVOSCloud/Analytics/AVAnalytics.h
+++ b/AVOS/AVOSCloud/Analytics/AVAnalytics.h
@@ -124,27 +124,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)setLogSendInterval:(double)second;
 
-
-///---------------------------------------------------------------------------------------
-/// @name  开启统计(已废止)
-///---------------------------------------------------------------------------------------
-
-
-/** 开启统计,默认以AV_BATCH方式发送log. 1.4.3以后不再需要，请前往在线配置进行配置。
- https://leancloud.cn/stat.html?appid=YOUR_APP_ID&os=ios#/statconfig/trans_strategoy
- */
-
-+ (void)start AV_DEPRECATED("1.4.3以后不再需要，请前往在线配置进行配置");
-
-/** 开启统计,默认以AV_BATCH方式发送log. 1.4.3以后不再需要，请前往在线配置进行配置。
- https://leancloud.cn/stat.html?appid=YOUR_APP_ID&os=ios#/statconfig/trans_strategoy
-
- @param rp 发送策略.
- @param cid 渠道名称,为nil或@""时,默认会被被当作@"App Store"渠道
- */
-+ (void)startWithReportPolicy:(AVReportPolicy)rp channelId:(nullable NSString *)cid AV_DEPRECATED("1.4.3以后不再需要，请前往在线配置进行配置");
-
-
 /** 跟踪 app 打开情况
  @discussion 该方法应在 "- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions" 中调用
  @param launchOptions 对应上述方法的参数launchOptions

--- a/AVOS/AVOSCloud/Analytics/AVAnalytics.m
+++ b/AVOS/AVOSCloud/Analytics/AVAnalytics.m
@@ -46,16 +46,6 @@ static NSString * currentSessionId;
     [AVAnalytics event:appOpenWithPush];
 }
 
-+ (void)start
-{
-    [AVAnalytics startWithReportPolicy:AV_BATCH channelId:@""];
-}
-
-+ (void)startWithReportPolicy:(AVReportPolicy)rp channelId:(NSString *)cid
-{
-    AVLoggerError(AVLoggerDomainDefault, @"The method is not supported anymore, please visit application web console to config.");
-}
-
 + (void)startInternallyWithChannel:(NSString *)cid
 {
     if (cid.length > 0) {


### PR DESCRIPTION
移除开启统计的方法，这些方法除了打印错误日志外，什么都不做。已经作废了很长一段时间。Android SDK 也准备 private 这些方法。

@leancloud/ios-group @leancloud/android-group