### PR TITLE
Fix crash when checking jail broken

### DIFF
--- a/AVOS/AVOSCloud/Analytics/AVAnalyticsUtils.m
+++ b/AVOS/AVOSCloud/Analytics/AVAnalyticsUtils.m
@@ -83,14 +83,18 @@ static NSString * identifierForVendorTag = @"identifierForVendor";
 
 + (BOOL) isJailbroken
 {
-    BOOL isJailbroken = NO;
-    BOOL cydiaInstalled = [[NSFileManager defaultManager] fileExistsAtPath:@"/Applications/Cydia.app"];
-    FILE *f = fopen("/bin/bash", "r");
-    if (!(errno == ENOENT) && cydiaInstalled) {
-        isJailbroken = YES;
+#if TARGET_OS_SIMULATOR
+    return NO;
+#else
+    FILE *bash = fopen("/bin/bash", "r");
+
+    if (bash) {
+        fclose(bash);
+        return YES;
     }
-    fclose(f);
-    return isJailbroken;
+
+    return NO;
+#endif
 }
 
 +(NSString *)screenResolution


### PR DESCRIPTION
修复检查设备是否越狱时，crash 的问题。另外，此处不再检查 Cydia，因为并非所有越狱设备都会安装 Cydia。关联 https://forum.leancloud.cn/t/oc-sdk-debug-avanalyticsutils-m-isjailbroken/13040。

@leancloud/ios-group @leancloud/tech-support 