### PR TITLE
Rename external symbols in protobuf

### DIFF
--- a/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMApi.pbobjc.h
+++ b/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMApi.pbobjc.h
@@ -129,13 +129,13 @@ typedef GPB_ENUM(GPBApi_FieldNumber) {
  * Fetches the raw value of a @c GPBApi's @c syntax property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBApi_Syntax_RawValue(LCIMApi *message);
+int32_t LCIMGPBApi_Syntax_RawValue(LCIMApi *message);
 /**
  * Sets the raw value of an @c GPBApi's @c syntax property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBApi_Syntax_RawValue(LCIMApi *message, int32_t value);
+void LCIMSetGPBApi_Syntax_RawValue(LCIMApi *message, int32_t value);
 
 #pragma mark - GPBMethod
 
@@ -183,13 +183,13 @@ typedef GPB_ENUM(GPBMethod_FieldNumber) {
  * Fetches the raw value of a @c GPBMethod's @c syntax property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBMethod_Syntax_RawValue(LCIMMethod *message);
+int32_t LCIMGPBMethod_Syntax_RawValue(LCIMMethod *message);
 /**
  * Sets the raw value of an @c GPBMethod's @c syntax property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBMethod_Syntax_RawValue(LCIMMethod *message, int32_t value);
+void LCIMSetGPBMethod_Syntax_RawValue(LCIMMethod *message, int32_t value);
 
 #pragma mark - GPBMixin
 

--- a/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMApi.pbobjc.m
+++ b/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMApi.pbobjc.m
@@ -169,13 +169,13 @@ typedef struct LCIMApi__storage_ {
 
 @end
 
-int32_t GPBApi_Syntax_RawValue(LCIMApi *message) {
+int32_t LCIMGPBApi_Syntax_RawValue(LCIMApi *message) {
   LCIMDescriptor *descriptor = [LCIMApi descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBApi_FieldNumber_Syntax];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBApi_Syntax_RawValue(LCIMApi *message, int32_t value) {
+void LCIMSetGPBApi_Syntax_RawValue(LCIMApi *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMApi descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBApi_FieldNumber_Syntax];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
@@ -293,13 +293,13 @@ typedef struct LCIMMethod__storage_ {
 
 @end
 
-int32_t GPBMethod_Syntax_RawValue(LCIMMethod *message) {
+int32_t LCIMGPBMethod_Syntax_RawValue(LCIMMethod *message) {
   LCIMDescriptor *descriptor = [LCIMMethod descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBMethod_FieldNumber_Syntax];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBMethod_Syntax_RawValue(LCIMMethod *message, int32_t value) {
+void LCIMSetGPBMethod_Syntax_RawValue(LCIMMethod *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMMethod descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBMethod_FieldNumber_Syntax];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);

--- a/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMStruct.pbobjc.h
+++ b/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMStruct.pbobjc.h
@@ -159,18 +159,18 @@ typedef GPB_ENUM(GPBValue_Kind_OneOfCase) {
  * Fetches the raw value of a @c GPBValue's @c nullValue property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBValue_NullValue_RawValue(LCIMValue *message);
+int32_t LCIMGPBValue_NullValue_RawValue(LCIMValue *message);
 /**
  * Sets the raw value of an @c GPBValue's @c nullValue property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBValue_NullValue_RawValue(LCIMValue *message, int32_t value);
+void LCIMSetGPBValue_NullValue_RawValue(LCIMValue *message, int32_t value);
 
 /**
  * Clears whatever value was set for the oneof 'kind'.
  **/
-void GPBValue_ClearKindOneOfCase(LCIMValue *message);
+void LCIMGPBValue_ClearKindOneOfCase(LCIMValue *message);
 
 #pragma mark - GPBListValue
 

--- a/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMStruct.pbobjc.m
+++ b/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMStruct.pbobjc.m
@@ -226,19 +226,19 @@ typedef struct LCIMValue__storage_ {
 
 @end
 
-int32_t GPBValue_NullValue_RawValue(LCIMValue *message) {
+int32_t LCIMGPBValue_NullValue_RawValue(LCIMValue *message) {
   LCIMDescriptor *descriptor = [LCIMValue descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBValue_FieldNumber_NullValue];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBValue_NullValue_RawValue(LCIMValue *message, int32_t value) {
+void LCIMSetGPBValue_NullValue_RawValue(LCIMValue *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMValue descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBValue_FieldNumber_NullValue];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
 }
 
-void GPBValue_ClearKindOneOfCase(LCIMValue *message) {
+void LCIMGPBValue_ClearKindOneOfCase(LCIMValue *message) {
   LCIMDescriptor *descriptor = [message descriptor];
   LCIMOneofDescriptor *oneof = descriptor->oneofs_[0];
   LCIMMaybeClearOneof(message, oneof, -1, 0);

--- a/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMType.pbobjc.h
+++ b/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMType.pbobjc.h
@@ -230,13 +230,13 @@ typedef GPB_ENUM(GPBType_FieldNumber) {
  * Fetches the raw value of a @c GPBType's @c syntax property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBType_Syntax_RawValue(LCIMType *message);
+int32_t LCIMGPBType_Syntax_RawValue(LCIMType *message);
 /**
  * Sets the raw value of an @c GPBType's @c syntax property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBType_Syntax_RawValue(LCIMType *message, int32_t value);
+void LCIMSetGPBType_Syntax_RawValue(LCIMType *message, int32_t value);
 
 #pragma mark - GPBField
 
@@ -302,25 +302,25 @@ typedef GPB_ENUM(GPBField_FieldNumber) {
  * Fetches the raw value of a @c GPBField's @c kind property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBField_Kind_RawValue(LCIMField *message);
+int32_t LCIMGPBField_Kind_RawValue(LCIMField *message);
 /**
  * Sets the raw value of an @c GPBField's @c kind property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBField_Kind_RawValue(LCIMField *message, int32_t value);
+void LCIMSetGPBField_Kind_RawValue(LCIMField *message, int32_t value);
 
 /**
  * Fetches the raw value of a @c GPBField's @c cardinality property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBField_Cardinality_RawValue(LCIMField *message);
+int32_t LCIMGPBField_Cardinality_RawValue(LCIMField *message);
 /**
  * Sets the raw value of an @c GPBField's @c cardinality property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBField_Cardinality_RawValue(LCIMField *message, int32_t value);
+void LCIMSetGPBField_Cardinality_RawValue(LCIMField *message, int32_t value);
 
 #pragma mark - GPBEnum
 
@@ -364,13 +364,13 @@ typedef GPB_ENUM(GPBEnum_FieldNumber) {
  * Fetches the raw value of a @c GPBEnum's @c syntax property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GPBEnum_Syntax_RawValue(LCIMEnum *message);
+int32_t LCIMGPBEnum_Syntax_RawValue(LCIMEnum *message);
 /**
  * Sets the raw value of an @c GPBEnum's @c syntax property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGPBEnum_Syntax_RawValue(LCIMEnum *message, int32_t value);
+void LCIMSetGPBEnum_Syntax_RawValue(LCIMEnum *message, int32_t value);
 
 #pragma mark - GPBEnumValue
 

--- a/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMType.pbobjc.m
+++ b/AVOS/AVOSCloudIM/Protobuf/google/protobuf/LCIMType.pbobjc.m
@@ -182,13 +182,13 @@ typedef struct GPBType__storage_ {
 
 @end
 
-int32_t GPBType_Syntax_RawValue(LCIMType *message) {
+int32_t LCIMGPBType_Syntax_RawValue(LCIMType *message) {
   LCIMDescriptor *descriptor = [LCIMType descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBType_FieldNumber_Syntax];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBType_Syntax_RawValue(LCIMType *message, int32_t value) {
+void LCIMSetGPBType_Syntax_RawValue(LCIMType *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMType descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBType_FieldNumber_Syntax];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
@@ -340,25 +340,25 @@ typedef struct LCIMField__storage_ {
 
 @end
 
-int32_t GPBField_Kind_RawValue(LCIMField *message) {
+int32_t LCIMGPBField_Kind_RawValue(LCIMField *message) {
   LCIMDescriptor *descriptor = [LCIMField descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBField_FieldNumber_Kind];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBField_Kind_RawValue(LCIMField *message, int32_t value) {
+void LCIMSetGPBField_Kind_RawValue(LCIMField *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMField descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBField_FieldNumber_Kind];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
 }
 
-int32_t GPBField_Cardinality_RawValue(LCIMField *message) {
+int32_t LCIMGPBField_Cardinality_RawValue(LCIMField *message) {
   LCIMDescriptor *descriptor = [LCIMField descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBField_FieldNumber_Cardinality];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBField_Cardinality_RawValue(LCIMField *message, int32_t value) {
+void LCIMSetGPBField_Cardinality_RawValue(LCIMField *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMField descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBField_FieldNumber_Cardinality];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
@@ -564,13 +564,13 @@ typedef struct LCIMEnum__storage_ {
 
 @end
 
-int32_t GPBEnum_Syntax_RawValue(LCIMEnum *message) {
+int32_t LCIMGPBEnum_Syntax_RawValue(LCIMEnum *message) {
   LCIMDescriptor *descriptor = [LCIMEnum descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBEnum_FieldNumber_Syntax];
   return LCIMGetMessageInt32Field(message, field);
 }
 
-void SetGPBEnum_Syntax_RawValue(LCIMEnum *message, int32_t value) {
+void LCIMSetGPBEnum_Syntax_RawValue(LCIMEnum *message, int32_t value) {
   LCIMDescriptor *descriptor = [LCIMEnum descriptor];
   LCIMFieldDescriptor *field = [descriptor fieldWithNumber:GPBEnum_FieldNumber_Syntax];
   LCIMSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);


### PR DESCRIPTION
重命名 protobuf 中的外部符号，防止与用户使用的 protobuf 冲突。 @leancloud/ios-group