### PR TITLE
Rename external symbols in networking library

### DIFF
--- a/AVOS/AVOSCloud/ThirdParty/LCNetworking/LCURLResponseSerialization.h
+++ b/AVOS/AVOSCloud/ThirdParty/LCNetworking/LCURLResponseSerialization.h
@@ -161,7 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
  - `application/xml`
  - `text/xml`
  */
-@interface AFXMLDocumentResponseSerializer : LCHTTPResponseSerializer
+@interface LCXMLDocumentResponseSerializer : LCHTTPResponseSerializer
 
 - (instancetype)init;
 

--- a/AVOS/AVOSCloud/ThirdParty/LCNetworking/LCURLResponseSerialization.m
+++ b/AVOS/AVOSCloud/ThirdParty/LCNetworking/LCURLResponseSerialization.m
@@ -339,14 +339,14 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 
 #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
 
-@implementation AFXMLDocumentResponseSerializer
+@implementation LCXMLDocumentResponseSerializer
 
 + (instancetype)serializer {
     return [self serializerWithXMLDocumentOptions:0];
 }
 
 + (instancetype)serializerWithXMLDocumentOptions:(NSUInteger)mask {
-    AFXMLDocumentResponseSerializer *serializer = [[self alloc] init];
+    LCXMLDocumentResponseSerializer *serializer = [[self alloc] init];
     serializer.options = mask;
 
     return serializer;
@@ -407,7 +407,7 @@ static id AFJSONObjectByRemovingKeysWithNullValues(id JSONObject, NSJSONReadingO
 #pragma mark - NSCopying
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    AFXMLDocumentResponseSerializer *serializer = [[[self class] allocWithZone:zone] init];
+    LCXMLDocumentResponseSerializer *serializer = [[[self class] allocWithZone:zone] init];
     serializer.options = self.options;
 
     return serializer;


### PR DESCRIPTION
修复应用依赖的 AFNetworking 与 SDK 依赖的 AFNetworking 冲突的问题，关联 #173 。

@leancloud/ios-group 