### PR TITLE
Support custom apns topic

### DIFF
--- a/AVOS/AVOSCloud/Push/AVInstallation.h
+++ b/AVOS/AVOSCloud/Push/AVInstallation.h
@@ -84,6 +84,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// The channels for the AVInstallation.
 @property (nonatomic, strong, nullable) NSArray *channels;
 
+/// The apns topic for universal push notification.
+@property (nonatomic, copy, nullable) NSString *apnsTopic;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AVOS/AVOSCloud/Push/AVInstallation.m
+++ b/AVOS/AVOSCloud/Push/AVInstallation.m
@@ -65,6 +65,7 @@
         self.className  = [AVInstallation className];
         self.deviceType = [AVInstallation deviceType];
         self.timeZone   = [[NSTimeZone systemTimeZone] name];
+        self.apnsTopic  = [NSBundle mainBundle].bundleIdentifier;
         
         NSString *path = [AVPersistenceUtils currentInstallationArchivePath];
         if ([AVPersistenceUtils fileExist:path]) {
@@ -156,7 +157,6 @@
         badgeTag: @(self.badge),
         deviceTypeTag: [AVInstallation deviceType],
         timeZoneTag: self.timeZone,
-        topicTag: [NSBundle mainBundle].bundleIdentifier ?: @""
     }];
 
     if (self.objectId) {
@@ -177,6 +177,9 @@
     if (self.deviceProfile)
     {
         [data setObject:self.deviceProfile forKey:deviceProfileTag];
+    }
+    if (self.apnsTopic) {
+        [data setObject:self.apnsTopic forKey:topicTag];
     }
 
     NSDictionary *updationData = [AVObjectUtils dictionaryFromObject:self.localData];


### PR DESCRIPTION
支持自定义 installation 的 apns topic。之前这个字段是由 SDK 内部读取 app 信息来设置的，没有对用户开放。但有些应用（例如 VOIP 应用）需要自定义该字段才能使用 Universal 推送，因此把接口开放出去。

@leancloud/ios-group @leancloud/push