### PR TITLE
Refine client status for open and close

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -517,7 +517,7 @@ static BOOL AVIMClientHasInstantiated = NO;
     dispatch_async(imClientQueue, ^{
         @strongify(self);
 
-        if (self.status == AVIMClientStatusNone || self.status == AVIMClientStatusClosed) {
+        if (self.status != AVIMClientStatusOpened) {
             self.clientId = clientId;
             self.tag = tag;
             self.socketWrapper = [self socketWrapperForSecurity:security];
@@ -587,6 +587,11 @@ static BOOL AVIMClientHasInstantiated = NO;
 
 - (void)closeWithCallback:(AVIMBooleanResultBlock)callback {
     dispatch_async(imClientQueue, ^{
+        if (self.status == AVIMClientStatusClosed) {
+            [AVIMBlockHelper callBooleanResultBlock:callback error:nil];
+            return;
+        }
+
         AVIMGenericCommand *genericCommand = [[AVIMGenericCommand alloc] init];
         genericCommand.needResponse = YES;
         genericCommand.cmd = AVIMCommandType_Session;


### PR DESCRIPTION
改进 client 的登录登出状态：

1. 当 client 的状态不是 opened 时，可以发出登录请求；
2. 当 client 状态已经是 closed 时，直接返回成功。

@leancloud/ios-group 