### PR TITLE
Filter out duplicated message within each client

### DIFF
--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.h
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.h
@@ -39,9 +39,6 @@ FOUNDATION_EXPORT NSString *const AVIMProtocolPROTOBUF2;
 - (void)closeWebSocketConnection;
 - (void)closeWebSocketConnectionRetry:(BOOL)retry;
 - (void)sendCommand:(AVIMGenericCommand *)genericCommand;
-//- (void)sendMessage:(id)data;
 - (void)sendPing;
 - (BOOL)isConnectionOpen;
-- (BOOL)messageIdExists:(NSString *)messageId;
-- (void)addMessageId:(NSString *)messageId;
 @end

--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -91,7 +91,6 @@ NSString *const AVIMProtocolPROTOBUF2 = @"lc.protobuf.2";
     BOOL _waitingForPong;
     NSMutableDictionary *_commandDictionary;
     NSMutableArray *_serialIdArray;
-    NSMutableArray *_messageIdArray;
 }
 
 @property (nonatomic, assign) BOOL security;
@@ -137,11 +136,8 @@ NSString *const AVIMProtocolPROTOBUF2 = @"lc.protobuf.2";
 - (id)init {
     self = [super init];
     if (self) {
-        //        _dataQueue = [[NSMutableArray alloc] init];
-        //        _commandQueue = [[NSMutableArray alloc] init];
         _commandDictionary = [[NSMutableDictionary alloc] init];
         _serialIdArray = [[NSMutableArray alloc] init];
-        _messageIdArray = [[NSMutableArray alloc] init];
         _ttl = -1;
         _observerCount = 0;
         _timeout = AVIMWebSocketDefaultTimeoutInterval;
@@ -233,49 +229,30 @@ NSString *const AVIMProtocolPROTOBUF2 = @"lc.protobuf.2";
     }
 }
 
-- (void)addMessageId:(NSString *)messageId {
-    if (![_messageIdArray containsObject:messageId]) {
-        [_messageIdArray addObject:messageId];
-    }
-    while (1) {
-        if (_messageIdArray.count > 5) {
-            [_messageIdArray removeObjectAtIndex:0];
-        } else {
-            break;
-        }
-    }
-}
-
-- (BOOL)messageIdExists:(NSString *)messageId {
-    return [_messageIdArray containsObject:messageId];
-}
-
 #pragma mark - process application notification
+
 - (void)applicationDidFinishLaunching:(id)sender {
-    _messageIdArray = [[[NSUserDefaults standardUserDefaults] arrayForKey:@"AVIMMessageIdArray"] mutableCopy];
+    /* Nothing to do. */
 }
 
 - (void)applicationDidEnterBackground:(id)sender {
     [self closeWebSocketConnectionRetry:NO];
-    [[NSUserDefaults standardUserDefaults] setObject:_messageIdArray forKey:@"AVIMMessageIdArray"];
-    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 - (void)applicationWillEnterForeground:(id)sender {
-    _messageIdArray = [[[NSUserDefaults standardUserDefaults] arrayForKey:@"AVIMMessageIdArray"] mutableCopy];
     _reconnectInterval = 1;
+
     if (_observerCount > 0) {
         [self openWebSocketConnection];
     }
 }
 
 - (void)applicationWillResignActive:(id)sender {
-    [[NSUserDefaults standardUserDefaults] setObject:_messageIdArray forKey:@"AVIMMessageIdArray"];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    /* Nothing to do. */
 }
 
 - (void)applicationDidBecomeActive:(id)sender {
-    _messageIdArray = [[[NSUserDefaults standardUserDefaults] arrayForKey:@"AVIMMessageIdArray"] mutableCopy];
+    /* Nothing to do. */
 }
 
 - (void)applicationWillTerminate:(id)sender {


### PR DESCRIPTION
将消息的去重逻辑转移到 client 内部。之前的去重逻辑是放在 socket 对象中的，但这样会导致一个问题：由于 socket 是被所有 clients 共享，如果当前连接上的多个 clients 收到的消息 ID 相同，本不应该过滤的消息会被过滤掉。

另外，还将用于去重的数组长度从 5 调整为 10，并去掉了对该数组的持久化存储。

@leancloud/ios-group @leancloud/android-group @leancloud/javascript-group 