### PR TITLE
Mark message as a breakpoint when message did receive

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -991,7 +991,7 @@ static BOOL AVIMClientHasInstantiated = NO;
         }
         
         /* Otherwise, add message to cache and notify it to user */
-        [cacheStore insertMessage:message withBreakpoint:message.offline && message.hasMore];
+        [cacheStore insertMessage:message withBreakpoint:YES];
     }
     
     AVIMConversation *conversation = [self conversationWithId:conversationId];


### PR DESCRIPTION
把接收到的消息始终标记为断点，修复 #213 中描述的问题。
问题的根源是由 https://github.com/leancloud/ios-sdk/issues/210 这个提议导致的，当时没有考虑到 #213 中描述的场景。

请 @leancloud/android-group 确认是否存在同样的问题。 @leancloud/ios-group @nicecui 