### PR TITLE
Support to query online clients in IM 2.0

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMClient.h
+++ b/AVOS/AVOSCloudIM/AVIMClient.h
@@ -187,6 +187,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (AVIMConversationQuery *)conversationQuery;
 
+/*!
+ Query online clients within the given array of clients.
+
+ @note Currently, It only supports to query 20 clients at most.
+
+ @param clients  An array of clients you want to query.
+ @param callback The callback of query.
+ */
+- (void)queryOnlineClientsInClients:(NSArray<NSString *> *)clients callback:(AVIMArrayResultBlock)callback;
+
 @end
 
 /**


### PR DESCRIPTION
支持查询在线 clients，之前这个实现在 IM 1.0 中，现在把它移到了 IM 2.0 中。

@leancloud/ios-group 