### PR TITLE
Update cocoapods repo before push

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -59,7 +59,7 @@ module Podspec
         ok = false
 
         20.times do
-          ok = system("pod trunk push --allow-warnings #{file}")
+          ok = system("pod repo update && pod trunk push --allow-warnings #{file}")
 
           if ok
             log("succeed to push #{file}")


### PR DESCRIPTION
推送 pod 前先更新 CocoaPods 本地仓库，保证在 lint 时，其他模块才能依赖最新的基础模块。

@leancloud/ios-group 