### PR TITLE
Support short message capthca

### DIFF
--- a/AVOS/AVOS.xcodeproj/project.pbxproj
+++ b/AVOS/AVOS.xcodeproj/project.pbxproj
@@ -507,6 +507,14 @@
 		834B4A8F1B93ED3F00A7ADBC /* LCIMConversationCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 834B4A8D1B93ED3F00A7ADBC /* LCIMConversationCache.m */; };
 		834B4A9C1B94080500A7ADBC /* LCIMConversationQueryCacheStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 834B4A9A1B94080500A7ADBC /* LCIMConversationQueryCacheStore.h */; };
 		834B4A9D1B94080500A7ADBC /* LCIMConversationQueryCacheStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 834B4A9B1B94080500A7ADBC /* LCIMConversationQueryCacheStore.m */; };
+		835091FD1EB1BDD0000DA884 /* AVSMS.h in Headers */ = {isa = PBXBuildFile; fileRef = 835091FB1EB1BDD0000DA884 /* AVSMS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		835091FE1EB1BDD0000DA884 /* AVSMS.h in Headers */ = {isa = PBXBuildFile; fileRef = 835091FB1EB1BDD0000DA884 /* AVSMS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		835091FF1EB1BDD0000DA884 /* AVSMS.h in Headers */ = {isa = PBXBuildFile; fileRef = 835091FB1EB1BDD0000DA884 /* AVSMS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		835092001EB1BDD0000DA884 /* AVSMS.h in Headers */ = {isa = PBXBuildFile; fileRef = 835091FB1EB1BDD0000DA884 /* AVSMS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		835092011EB1BDD0000DA884 /* AVSMS.m in Sources */ = {isa = PBXBuildFile; fileRef = 835091FC1EB1BDD0000DA884 /* AVSMS.m */; };
+		835092021EB1BDD0000DA884 /* AVSMS.m in Sources */ = {isa = PBXBuildFile; fileRef = 835091FC1EB1BDD0000DA884 /* AVSMS.m */; };
+		835092031EB1BDD0000DA884 /* AVSMS.m in Sources */ = {isa = PBXBuildFile; fileRef = 835091FC1EB1BDD0000DA884 /* AVSMS.m */; };
+		835092041EB1BDD0000DA884 /* AVSMS.m in Sources */ = {isa = PBXBuildFile; fileRef = 835091FC1EB1BDD0000DA884 /* AVSMS.m */; };
 		835C5F711D25929600EF0EBB /* AVFriendQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C841A651A5A79FF00C5C6C4 /* AVFriendQuery.h */; };
 		835C5F721D2594EA00EF0EBB /* AVAnalyticsActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C8419E71A5A79FF00C5C6C4 /* AVAnalyticsActivity.h */; };
 		835E015A1B3192240025F99A /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 835E01591B3192240025F99A /* CoreLocation.framework */; };
@@ -1423,6 +1431,8 @@
 		834B4A8D1B93ED3F00A7ADBC /* LCIMConversationCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LCIMConversationCache.m; sourceTree = "<group>"; };
 		834B4A9A1B94080500A7ADBC /* LCIMConversationQueryCacheStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LCIMConversationQueryCacheStore.h; sourceTree = "<group>"; };
 		834B4A9B1B94080500A7ADBC /* LCIMConversationQueryCacheStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LCIMConversationQueryCacheStore.m; sourceTree = "<group>"; };
+		835091FB1EB1BDD0000DA884 /* AVSMS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVSMS.h; sourceTree = "<group>"; };
+		835091FC1EB1BDD0000DA884 /* AVSMS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVSMS.m; sourceTree = "<group>"; };
 		835E01591B3192240025F99A /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		835E015B1B31922B0025F99A /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		835E015D1B31922F0025F99A /* libicucore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libicucore.dylib; path = usr/lib/libicucore.dylib; sourceTree = SDKROOT; };
@@ -2011,6 +2021,15 @@
 			path = COSObserver;
 			sourceTree = "<group>";
 		};
+		835091FA1EB1BD90000DA884 /* SMS */ = {
+			isa = PBXGroup;
+			children = (
+				835091FB1EB1BDD0000DA884 /* AVSMS.h */,
+				835091FC1EB1BDD0000DA884 /* AVSMS.m */,
+			);
+			path = SMS;
+			sourceTree = "<group>";
+		};
 		836705A91BA1358D0050E968 /* SDMacros */ = {
 			isa = PBXGroup;
 			children = (
@@ -2422,6 +2441,7 @@
 				8C841A7A1A5A7A0000C5C6C4 /* ThirdParty */,
 				8C841A9B1A5A7A0000C5C6C4 /* User */,
 				8C841AA11A5A7A0000C5C6C4 /* Utils */,
+				835091FA1EB1BD90000DA884 /* SMS */,
 			);
 			path = AVOSCloud;
 			sourceTree = "<group>";
@@ -3188,6 +3208,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				835091FE1EB1BDD0000DA884 /* AVSMS.h in Headers */,
 				70CA800D1BDE4314000A3B21 /* AVSearchQuery.h in Headers */,
 				70CA800E1BDE4314000A3B21 /* AVSearchSortBuilder.h in Headers */,
 				70CA7FE71BDE42F6000A3B21 /* AVConstants.h in Headers */,
@@ -3300,6 +3321,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				835092001EB1BDD0000DA884 /* AVSMS.h in Headers */,
 				8320F8D91C1918C60024B45E /* AVACL.h in Headers */,
 				8320F8DA1C1918C60024B45E /* LCDB.h in Headers */,
 				8320F8DB1C1918C60024B45E /* AVRole.h in Headers */,
@@ -3404,6 +3426,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				835091FF1EB1BDD0000DA884 /* AVSMS.h in Headers */,
 				83D8CED21C17DAF50094279D /* AVACL.h in Headers */,
 				83FCB9CF1CEDC57C007D8712 /* LCURLResponseSerialization.h in Headers */,
 				83D8CED31C17DAF50094279D /* LCDB.h in Headers */,
@@ -3573,6 +3596,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				835091FD1EB1BDD0000DA884 /* AVSMS.h in Headers */,
 				8C841AAD1A5A7A0000C5C6C4 /* AVACL.h in Headers */,
 				83DF02B81AF86032000E289C /* LCDB.h in Headers */,
 				8C841AB01A5A7A0000C5C6C4 /* AVRole.h in Headers */,
@@ -4346,6 +4370,7 @@
 				70CA7F931BDE3721000A3B21 /* AVSearchSortBuilder.m in Sources */,
 				70CA7F941BDE3721000A3B21 /* LCNetworkStatistics.m in Sources */,
 				70CA7F951BDE3721000A3B21 /* AVStatus.m in Sources */,
+				835092021EB1BDD0000DA884 /* AVSMS.m in Sources */,
 				83FCB9BF1CEDC57C007D8712 /* LCSecurityPolicy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4402,6 +4427,7 @@
 				8320F88D1C1918C60024B45E /* LCDatabase.m in Sources */,
 				8320F88E1C1918C60024B45E /* NSDictionary+LCHash.m in Sources */,
 				83FCB9D51CEDC57C007D8712 /* LCURLResponseSerialization.m in Sources */,
+				835092041EB1BDD0000DA884 /* AVSMS.m in Sources */,
 				8320F88F1C1918C60024B45E /* AVKeychain.m in Sources */,
 				8320F8901C1918C60024B45E /* AVQuery.m in Sources */,
 				83FCB9DF1CEDC57C007D8712 /* LCURLSessionManager.m in Sources */,
@@ -4512,6 +4538,7 @@
 				83E13C171D4B4FC60009CB6F /* AVConfiguration.m in Sources */,
 				83D8CEA71C17DAF50094279D /* AVExceptionHandler.m in Sources */,
 				83D8CEA81C17DAF50094279D /* AVRole.m in Sources */,
+				835092031EB1BDD0000DA884 /* AVSMS.m in Sources */,
 				83D8CEA91C17DAF50094279D /* AVPaasClient.m in Sources */,
 				8302AEDD1C192A0700E13F8A /* LCURLConnection.m in Sources */,
 				83D8CEAA1C17DAF50094279D /* AVHTTPRequestOperation.m in Sources */,
@@ -4641,6 +4668,7 @@
 				83E13C151D4B4FC60009CB6F /* AVConfiguration.m in Sources */,
 				8C841AC11A5A7A0000C5C6C4 /* AVExceptionHandler.m in Sources */,
 				8C841AB11A5A7A0000C5C6C4 /* AVRole.m in Sources */,
+				835092011EB1BDD0000DA884 /* AVSMS.m in Sources */,
 				8C841B331A5A7A0000C5C6C4 /* AVPaasClient.m in Sources */,
 				8302AEDA1C192A0700E13F8A /* LCURLConnection.m in Sources */,
 				8C841B411A5A7A0000C5C6C4 /* AVHTTPRequestOperation.m in Sources */,

--- a/AVOS/AVOS.xcodeproj/project.pbxproj
+++ b/AVOS/AVOS.xcodeproj/project.pbxproj
@@ -515,6 +515,14 @@
 		835092021EB1BDD0000DA884 /* AVSMS.m in Sources */ = {isa = PBXBuildFile; fileRef = 835091FC1EB1BDD0000DA884 /* AVSMS.m */; };
 		835092031EB1BDD0000DA884 /* AVSMS.m in Sources */ = {isa = PBXBuildFile; fileRef = 835091FC1EB1BDD0000DA884 /* AVSMS.m */; };
 		835092041EB1BDD0000DA884 /* AVSMS.m in Sources */ = {isa = PBXBuildFile; fileRef = 835091FC1EB1BDD0000DA884 /* AVSMS.m */; };
+		835092121EB1ECB7000DA884 /* AVDynamicObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 835092101EB1ECB7000DA884 /* AVDynamicObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		835092131EB1ECB7000DA884 /* AVDynamicObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 835092101EB1ECB7000DA884 /* AVDynamicObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		835092141EB1ECB7000DA884 /* AVDynamicObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 835092101EB1ECB7000DA884 /* AVDynamicObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		835092151EB1ECB7000DA884 /* AVDynamicObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 835092101EB1ECB7000DA884 /* AVDynamicObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		835092161EB1ECB7000DA884 /* AVDynamicObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 835092111EB1ECB7000DA884 /* AVDynamicObject.m */; };
+		835092171EB1ECB7000DA884 /* AVDynamicObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 835092111EB1ECB7000DA884 /* AVDynamicObject.m */; };
+		835092181EB1ECB7000DA884 /* AVDynamicObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 835092111EB1ECB7000DA884 /* AVDynamicObject.m */; };
+		835092191EB1ECB7000DA884 /* AVDynamicObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 835092111EB1ECB7000DA884 /* AVDynamicObject.m */; };
 		835C5F711D25929600EF0EBB /* AVFriendQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C841A651A5A79FF00C5C6C4 /* AVFriendQuery.h */; };
 		835C5F721D2594EA00EF0EBB /* AVAnalyticsActivity.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C8419E71A5A79FF00C5C6C4 /* AVAnalyticsActivity.h */; };
 		835E015A1B3192240025F99A /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 835E01591B3192240025F99A /* CoreLocation.framework */; };
@@ -1433,6 +1441,8 @@
 		834B4A9B1B94080500A7ADBC /* LCIMConversationQueryCacheStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LCIMConversationQueryCacheStore.m; sourceTree = "<group>"; };
 		835091FB1EB1BDD0000DA884 /* AVSMS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVSMS.h; sourceTree = "<group>"; };
 		835091FC1EB1BDD0000DA884 /* AVSMS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVSMS.m; sourceTree = "<group>"; };
+		835092101EB1ECB7000DA884 /* AVDynamicObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVDynamicObject.h; sourceTree = "<group>"; };
+		835092111EB1ECB7000DA884 /* AVDynamicObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVDynamicObject.m; sourceTree = "<group>"; };
 		835E01591B3192240025F99A /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		835E015B1B31922B0025F99A /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		835E015D1B31922F0025F99A /* libicucore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libicucore.dylib; path = usr/lib/libicucore.dylib; sourceTree = SDKROOT; };
@@ -2860,6 +2870,8 @@
 				837CC71D1B568431001333AD /* NSDictionary+LCHash.m */,
 				8302AED31C192A0600E13F8A /* LCURLConnection.h */,
 				8302AED41C192A0600E13F8A /* LCURLConnection.m */,
+				835092101EB1ECB7000DA884 /* AVDynamicObject.h */,
+				835092111EB1ECB7000DA884 /* AVDynamicObject.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3208,6 +3220,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				835092131EB1ECB7000DA884 /* AVDynamicObject.h in Headers */,
 				835091FE1EB1BDD0000DA884 /* AVSMS.h in Headers */,
 				70CA800D1BDE4314000A3B21 /* AVSearchQuery.h in Headers */,
 				70CA800E1BDE4314000A3B21 /* AVSearchSortBuilder.h in Headers */,
@@ -3321,6 +3334,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				835092151EB1ECB7000DA884 /* AVDynamicObject.h in Headers */,
 				835092001EB1BDD0000DA884 /* AVSMS.h in Headers */,
 				8320F8D91C1918C60024B45E /* AVACL.h in Headers */,
 				8320F8DA1C1918C60024B45E /* LCDB.h in Headers */,
@@ -3426,6 +3440,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				835092141EB1ECB7000DA884 /* AVDynamicObject.h in Headers */,
 				835091FF1EB1BDD0000DA884 /* AVSMS.h in Headers */,
 				83D8CED21C17DAF50094279D /* AVACL.h in Headers */,
 				83FCB9CF1CEDC57C007D8712 /* LCURLResponseSerialization.h in Headers */,
@@ -3596,6 +3611,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				835092121EB1ECB7000DA884 /* AVDynamicObject.h in Headers */,
 				835091FD1EB1BDD0000DA884 /* AVSMS.h in Headers */,
 				8C841AAD1A5A7A0000C5C6C4 /* AVACL.h in Headers */,
 				83DF02B81AF86032000E289C /* LCDB.h in Headers */,
@@ -4350,6 +4366,7 @@
 				70CA7F861BDE3721000A3B21 /* AVLocationManager.m in Sources */,
 				70CA7F871BDE3721000A3B21 /* AVObject.m in Sources */,
 				70CA7F881BDE3721000A3B21 /* AVObjectUtils.m in Sources */,
+				835092171EB1ECB7000DA884 /* AVDynamicObject.m in Sources */,
 				70CA7F891BDE3721000A3B21 /* AVRelation.m in Sources */,
 				83FCB9DD1CEDC57C007D8712 /* LCURLSessionManager.m in Sources */,
 				9A404DD81CE5A9C200DEB3DC /* LCRouter.m in Sources */,
@@ -4475,6 +4492,7 @@
 				8320F8CA1C1918C60024B45E /* AVScheduler.m in Sources */,
 				830EB9C91C3E4BFA00BA917F /* LCObserver.m in Sources */,
 				8320F8CC1C1918C60024B45E /* AVCloudQueryResult.m in Sources */,
+				835092191EB1ECB7000DA884 /* AVDynamicObject.m in Sources */,
 				8320F8CE1C1918C60024B45E /* AVImageRequestOperation.m in Sources */,
 				8320F8CF1C1918C60024B45E /* AVNetworkActivityIndicatorManager.m in Sources */,
 				8320F8D01C1918C60024B45E /* LCKeyValueStore.m in Sources */,
@@ -4558,6 +4576,7 @@
 				83D8CEB71C17DAF50094279D /* AVFriendQuery.m in Sources */,
 				83D8CEB81C17DAF50094279D /* AVPartialInputStream.m in Sources */,
 				83D8CEB91C17DAF50094279D /* AVPush.m in Sources */,
+				835092181EB1ECB7000DA884 /* AVDynamicObject.m in Sources */,
 				83D8CEBA1C17DAF50094279D /* LCDatabaseCoordinator.m in Sources */,
 				83D8CEBB1C17DAF50094279D /* AVGroup.m in Sources */,
 				83D8CEBC1C17DAF50094279D /* AVAckCommand.m in Sources */,
@@ -4688,6 +4707,7 @@
 				8C841B2B1A5A7A0000C5C6C4 /* AVFriendQuery.m in Sources */,
 				8C841AE41A5A7A0000C5C6C4 /* AVPartialInputStream.m in Sources */,
 				8C841B251A5A7A0000C5C6C4 /* AVPush.m in Sources */,
+				835092161EB1ECB7000DA884 /* AVDynamicObject.m in Sources */,
 				830E7CF91B1CA2A2005F4B22 /* LCDatabaseCoordinator.m in Sources */,
 				8C841AEF1A5A7A0000C5C6C4 /* AVGroup.m in Sources */,
 				8C841AFF1A5A7A0000C5C6C4 /* AVAckCommand.m in Sources */,

--- a/AVOS/AVOS.xcodeproj/project.pbxproj
+++ b/AVOS/AVOS.xcodeproj/project.pbxproj
@@ -500,6 +500,14 @@
 		8320F9511C1918C60024B45E /* AVCloudQueryResult_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C841A641A5A79FF00C5C6C4 /* AVCloudQueryResult_Internal.h */; };
 		8320F9541C1918C60024B45E /* AVPush_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C841A601A5A79FF00C5C6C4 /* AVPush_Internal.h */; };
 		8320F95E1C1918FE0024B45E /* AVOSCloud-watchOS.Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8320F95D1C1918FE0024B45E /* AVOSCloud-watchOS.Info.plist */; };
+		83331D451EB9A25F00CADC9C /* AVCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D431EB9A25F00CADC9C /* AVCaptcha.h */; };
+		83331D461EB9A25F00CADC9C /* AVCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D431EB9A25F00CADC9C /* AVCaptcha.h */; };
+		83331D471EB9A25F00CADC9C /* AVCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D431EB9A25F00CADC9C /* AVCaptcha.h */; };
+		83331D481EB9A25F00CADC9C /* AVCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D431EB9A25F00CADC9C /* AVCaptcha.h */; };
+		83331D491EB9A25F00CADC9C /* AVCaptcha.m in Sources */ = {isa = PBXBuildFile; fileRef = 83331D441EB9A25F00CADC9C /* AVCaptcha.m */; };
+		83331D4A1EB9A25F00CADC9C /* AVCaptcha.m in Sources */ = {isa = PBXBuildFile; fileRef = 83331D441EB9A25F00CADC9C /* AVCaptcha.m */; };
+		83331D4B1EB9A25F00CADC9C /* AVCaptcha.m in Sources */ = {isa = PBXBuildFile; fileRef = 83331D441EB9A25F00CADC9C /* AVCaptcha.m */; };
+		83331D4C1EB9A25F00CADC9C /* AVCaptcha.m in Sources */ = {isa = PBXBuildFile; fileRef = 83331D441EB9A25F00CADC9C /* AVCaptcha.m */; };
 		833E1F631B69F629002A691C /* AVIMFileMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 833E1F611B69F629002A691C /* AVIMFileMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		833E1F641B69F629002A691C /* AVIMFileMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 833E1F621B69F629002A691C /* AVIMFileMessage.m */; };
 		834775DC1B2A693400B5AF2E /* AVIMKeyedConversation_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 834775DB1B2A693400B5AF2E /* AVIMKeyedConversation_internal.h */; };
@@ -1432,6 +1440,8 @@
 		831E29591D882CBB006E502B /* AVIMMessageOption.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVIMMessageOption.m; sourceTree = "<group>"; };
 		8320F95C1C1918C60024B45E /* AVOSCloud.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AVOSCloud.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8320F95D1C1918FE0024B45E /* AVOSCloud-watchOS.Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "AVOSCloud-watchOS.Info.plist"; sourceTree = "<group>"; };
+		83331D431EB9A25F00CADC9C /* AVCaptcha.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVCaptcha.h; sourceTree = "<group>"; };
+		83331D441EB9A25F00CADC9C /* AVCaptcha.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVCaptcha.m; sourceTree = "<group>"; };
 		833E1F611B69F629002A691C /* AVIMFileMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVIMFileMessage.h; sourceTree = "<group>"; };
 		833E1F621B69F629002A691C /* AVIMFileMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVIMFileMessage.m; sourceTree = "<group>"; };
 		834775DB1B2A693400B5AF2E /* AVIMKeyedConversation_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVIMKeyedConversation_internal.h; sourceTree = "<group>"; };
@@ -2031,6 +2041,15 @@
 			path = COSObserver;
 			sourceTree = "<group>";
 		};
+		83331D421EB9A24D00CADC9C /* Captcha */ = {
+			isa = PBXGroup;
+			children = (
+				83331D431EB9A25F00CADC9C /* AVCaptcha.h */,
+				83331D441EB9A25F00CADC9C /* AVCaptcha.m */,
+			);
+			path = Captcha;
+			sourceTree = "<group>";
+		};
 		835091FA1EB1BD90000DA884 /* SMS */ = {
 			isa = PBXGroup;
 			children = (
@@ -2451,6 +2470,7 @@
 				8C841A7A1A5A7A0000C5C6C4 /* ThirdParty */,
 				8C841A9B1A5A7A0000C5C6C4 /* User */,
 				8C841AA11A5A7A0000C5C6C4 /* Utils */,
+				83331D421EB9A24D00CADC9C /* Captcha */,
 				835091FA1EB1BD90000DA884 /* SMS */,
 			);
 			path = AVOSCloud;
@@ -3312,6 +3332,7 @@
 				70CA7FE51BDE42F5000A3B21 /* AVDuration.h in Headers */,
 				70CA7FE61BDE42F5000A3B21 /* AVExceptionHandler.h in Headers */,
 				70CA7FE81BDE42F6000A3B21 /* AVGlobal.h in Headers */,
+				83331D461EB9A25F00CADC9C /* AVCaptcha.h in Headers */,
 				9A404DD41CE5A9B700DEB3DC /* LCRouter.h in Headers */,
 				70CA7FE91BDE42F6000A3B21 /* AVOSCloud_Internal.h in Headers */,
 				70CA7FEB1BDE42F6000A3B21 /* AVCacheManager.h in Headers */,
@@ -3366,6 +3387,7 @@
 				9A404DD61CE5A9BB00DEB3DC /* LCRouter.h in Headers */,
 				83FCB9DA1CEDC57C007D8712 /* LCURLSessionManager.h in Headers */,
 				8320F8F81C1918C60024B45E /* AVSearchQuery.h in Headers */,
+				83331D481EB9A25F00CADC9C /* AVCaptcha.h in Headers */,
 				83FCB9D01CEDC57C007D8712 /* LCURLResponseSerialization.h in Headers */,
 				8320F8FB1C1918C60024B45E /* LCDatabaseCoordinator.h in Headers */,
 				8320F8FC1C1918C60024B45E /* AVSearchSortBuilder.h in Headers */,
@@ -3524,6 +3546,7 @@
 				83D8CF1E1C17DAF50094279D /* AVAckCommand.h in Headers */,
 				83D8CF201C17DAF50094279D /* SDMacros.h in Headers */,
 				830EB9C31C3E4BFA00BA917F /* LCObserver.h in Headers */,
+				83331D471EB9A25F00CADC9C /* AVCaptcha.h in Headers */,
 				83D8CF211C17DAF50094279D /* AVFriendQuery.h in Headers */,
 				83D8CF221C17DAF50094279D /* AVObject_Internal.h in Headers */,
 				83D8CF231C17DAF50094279D /* AVRelation_Internal.h in Headers */,
@@ -3695,6 +3718,7 @@
 				830EB9C01C3E4BFA00BA917F /* LCObserver.h in Headers */,
 				8C841B2A1A5A7A0000C5C6C4 /* AVFriendQuery.h in Headers */,
 				8C841B1A1A5A7A0000C5C6C4 /* AVObject_Internal.h in Headers */,
+				83331D451EB9A25F00CADC9C /* AVCaptcha.h in Headers */,
 				8C841B1F1A5A7A0000C5C6C4 /* AVRelation_Internal.h in Headers */,
 				8C841AAF1A5A7A0000C5C6C4 /* AVACL_Internal.h in Headers */,
 				838DD7961B3D309F00C95897 /* LCNetworkStatistics.h in Headers */,
@@ -4383,6 +4407,7 @@
 				83FCB9B51CEDC57C007D8712 /* LCNetworkReachabilityManager.m in Sources */,
 				70CA7F901BDE3721000A3B21 /* AVRequestOperation.m in Sources */,
 				70CA7F911BDE3721000A3B21 /* AVPaasClient.m in Sources */,
+				83331D4A1EB9A25F00CADC9C /* AVCaptcha.m in Sources */,
 				70CA7F921BDE3721000A3B21 /* AVSearchQuery.m in Sources */,
 				70CA7F931BDE3721000A3B21 /* AVSearchSortBuilder.m in Sources */,
 				70CA7F941BDE3721000A3B21 /* LCNetworkStatistics.m in Sources */,
@@ -4449,6 +4474,7 @@
 				8320F8901C1918C60024B45E /* AVQuery.m in Sources */,
 				83FCB9DF1CEDC57C007D8712 /* LCURLSessionManager.m in Sources */,
 				8320F8961C1918C60024B45E /* AVPersistenceUtils.m in Sources */,
+				83331D4C1EB9A25F00CADC9C /* AVCaptcha.m in Sources */,
 				83FCB9C11CEDC57C007D8712 /* LCSecurityPolicy.m in Sources */,
 				8320F8981C1918C60024B45E /* AVAnonymousUtils.m in Sources */,
 				8320F8991C1918C60024B45E /* AVUser.m in Sources */,
@@ -4521,6 +4547,7 @@
 				83FCB9DE1CEDC57C007D8712 /* LCURLSessionManager.m in Sources */,
 				83D8CE841C17DAF50094279D /* AVHistoryMessage.m in Sources */,
 				83FCB9D41CEDC57C007D8712 /* LCURLResponseSerialization.m in Sources */,
+				83331D4B1EB9A25F00CADC9C /* AVCaptcha.m in Sources */,
 				83D8CE851C17DAF50094279D /* AVCommand.m in Sources */,
 				83D8CE861C17DAF50094279D /* LCDatabase.m in Sources */,
 				83D8CE871C17DAF50094279D /* NSDictionary+LCHash.m in Sources */,
@@ -4652,6 +4679,7 @@
 				83FCB9DB1CEDC57C007D8712 /* LCURLSessionManager.m in Sources */,
 				8C841AF21A5A7A0000C5C6C4 /* AVHistoryMessage.m in Sources */,
 				83FCB9D11CEDC57C007D8712 /* LCURLResponseSerialization.m in Sources */,
+				83331D491EB9A25F00CADC9C /* AVCaptcha.m in Sources */,
 				8C841B011A5A7A0000C5C6C4 /* AVCommand.m in Sources */,
 				83DF02B11AF86032000E289C /* LCDatabase.m in Sources */,
 				837CC71F1B568431001333AD /* NSDictionary+LCHash.m in Sources */,

--- a/AVOS/AVOS.xcodeproj/project.pbxproj
+++ b/AVOS/AVOS.xcodeproj/project.pbxproj
@@ -500,14 +500,26 @@
 		8320F9511C1918C60024B45E /* AVCloudQueryResult_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C841A641A5A79FF00C5C6C4 /* AVCloudQueryResult_Internal.h */; };
 		8320F9541C1918C60024B45E /* AVPush_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C841A601A5A79FF00C5C6C4 /* AVPush_Internal.h */; };
 		8320F95E1C1918FE0024B45E /* AVOSCloud-watchOS.Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8320F95D1C1918FE0024B45E /* AVOSCloud-watchOS.Info.plist */; };
-		83331D451EB9A25F00CADC9C /* AVCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D431EB9A25F00CADC9C /* AVCaptcha.h */; };
-		83331D461EB9A25F00CADC9C /* AVCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D431EB9A25F00CADC9C /* AVCaptcha.h */; };
-		83331D471EB9A25F00CADC9C /* AVCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D431EB9A25F00CADC9C /* AVCaptcha.h */; };
-		83331D481EB9A25F00CADC9C /* AVCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D431EB9A25F00CADC9C /* AVCaptcha.h */; };
+		83331D451EB9A25F00CADC9C /* AVCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D431EB9A25F00CADC9C /* AVCaptcha.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83331D461EB9A25F00CADC9C /* AVCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D431EB9A25F00CADC9C /* AVCaptcha.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83331D471EB9A25F00CADC9C /* AVCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D431EB9A25F00CADC9C /* AVCaptcha.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83331D481EB9A25F00CADC9C /* AVCaptcha.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D431EB9A25F00CADC9C /* AVCaptcha.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		83331D491EB9A25F00CADC9C /* AVCaptcha.m in Sources */ = {isa = PBXBuildFile; fileRef = 83331D441EB9A25F00CADC9C /* AVCaptcha.m */; };
 		83331D4A1EB9A25F00CADC9C /* AVCaptcha.m in Sources */ = {isa = PBXBuildFile; fileRef = 83331D441EB9A25F00CADC9C /* AVCaptcha.m */; };
 		83331D4B1EB9A25F00CADC9C /* AVCaptcha.m in Sources */ = {isa = PBXBuildFile; fileRef = 83331D441EB9A25F00CADC9C /* AVCaptcha.m */; };
 		83331D4C1EB9A25F00CADC9C /* AVCaptcha.m in Sources */ = {isa = PBXBuildFile; fileRef = 83331D441EB9A25F00CADC9C /* AVCaptcha.m */; };
+		83331D4E1EB9A34000CADC9C /* AVDynamicObject_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D4D1EB9A34000CADC9C /* AVDynamicObject_Internal.h */; };
+		83331D4F1EB9A34000CADC9C /* AVDynamicObject_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D4D1EB9A34000CADC9C /* AVDynamicObject_Internal.h */; };
+		83331D501EB9A34000CADC9C /* AVDynamicObject_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D4D1EB9A34000CADC9C /* AVDynamicObject_Internal.h */; };
+		83331D511EB9A34000CADC9C /* AVDynamicObject_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D4D1EB9A34000CADC9C /* AVDynamicObject_Internal.h */; };
+		83331D541EB9D55100CADC9C /* NSDictionary+LeanCloud.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D521EB9D55100CADC9C /* NSDictionary+LeanCloud.h */; };
+		83331D551EB9D55100CADC9C /* NSDictionary+LeanCloud.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D521EB9D55100CADC9C /* NSDictionary+LeanCloud.h */; };
+		83331D561EB9D55100CADC9C /* NSDictionary+LeanCloud.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D521EB9D55100CADC9C /* NSDictionary+LeanCloud.h */; };
+		83331D571EB9D55100CADC9C /* NSDictionary+LeanCloud.h in Headers */ = {isa = PBXBuildFile; fileRef = 83331D521EB9D55100CADC9C /* NSDictionary+LeanCloud.h */; };
+		83331D581EB9D55100CADC9C /* NSDictionary+LeanCloud.m in Sources */ = {isa = PBXBuildFile; fileRef = 83331D531EB9D55100CADC9C /* NSDictionary+LeanCloud.m */; };
+		83331D591EB9D55100CADC9C /* NSDictionary+LeanCloud.m in Sources */ = {isa = PBXBuildFile; fileRef = 83331D531EB9D55100CADC9C /* NSDictionary+LeanCloud.m */; };
+		83331D5A1EB9D55100CADC9C /* NSDictionary+LeanCloud.m in Sources */ = {isa = PBXBuildFile; fileRef = 83331D531EB9D55100CADC9C /* NSDictionary+LeanCloud.m */; };
+		83331D5B1EB9D55100CADC9C /* NSDictionary+LeanCloud.m in Sources */ = {isa = PBXBuildFile; fileRef = 83331D531EB9D55100CADC9C /* NSDictionary+LeanCloud.m */; };
 		833E1F631B69F629002A691C /* AVIMFileMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 833E1F611B69F629002A691C /* AVIMFileMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		833E1F641B69F629002A691C /* AVIMFileMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 833E1F621B69F629002A691C /* AVIMFileMessage.m */; };
 		834775DC1B2A693400B5AF2E /* AVIMKeyedConversation_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 834775DB1B2A693400B5AF2E /* AVIMKeyedConversation_internal.h */; };
@@ -1442,6 +1454,9 @@
 		8320F95D1C1918FE0024B45E /* AVOSCloud-watchOS.Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "AVOSCloud-watchOS.Info.plist"; sourceTree = "<group>"; };
 		83331D431EB9A25F00CADC9C /* AVCaptcha.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVCaptcha.h; sourceTree = "<group>"; };
 		83331D441EB9A25F00CADC9C /* AVCaptcha.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVCaptcha.m; sourceTree = "<group>"; };
+		83331D4D1EB9A34000CADC9C /* AVDynamicObject_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVDynamicObject_Internal.h; sourceTree = "<group>"; };
+		83331D521EB9D55100CADC9C /* NSDictionary+LeanCloud.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+LeanCloud.h"; sourceTree = "<group>"; };
+		83331D531EB9D55100CADC9C /* NSDictionary+LeanCloud.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+LeanCloud.m"; sourceTree = "<group>"; };
 		833E1F611B69F629002A691C /* AVIMFileMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVIMFileMessage.h; sourceTree = "<group>"; };
 		833E1F621B69F629002A691C /* AVIMFileMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVIMFileMessage.m; sourceTree = "<group>"; };
 		834775DB1B2A693400B5AF2E /* AVIMKeyedConversation_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVIMKeyedConversation_internal.h; sourceTree = "<group>"; };
@@ -2888,9 +2903,12 @@
 				838DD7C11B42630400C95897 /* LCSSLChallenger.m */,
 				837CC71C1B568431001333AD /* NSDictionary+LCHash.h */,
 				837CC71D1B568431001333AD /* NSDictionary+LCHash.m */,
+				83331D521EB9D55100CADC9C /* NSDictionary+LeanCloud.h */,
+				83331D531EB9D55100CADC9C /* NSDictionary+LeanCloud.m */,
 				8302AED31C192A0600E13F8A /* LCURLConnection.h */,
 				8302AED41C192A0600E13F8A /* LCURLConnection.m */,
 				835092101EB1ECB7000DA884 /* AVDynamicObject.h */,
+				83331D4D1EB9A34000CADC9C /* AVDynamicObject_Internal.h */,
 				835092111EB1ECB7000DA884 /* AVDynamicObject.m */,
 			);
 			path = Utils;
@@ -3240,6 +3258,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				83331D461EB9A25F00CADC9C /* AVCaptcha.h in Headers */,
 				835092131EB1ECB7000DA884 /* AVDynamicObject.h in Headers */,
 				835091FE1EB1BDD0000DA884 /* AVSMS.h in Headers */,
 				70CA800D1BDE4314000A3B21 /* AVSearchQuery.h in Headers */,
@@ -3289,6 +3308,7 @@
 				8311CD871C3D25B9007DEFF8 /* AVAvailability.h in Headers */,
 				70CA80131BDE4314000A3B21 /* AVHTTPRequestOperation.h in Headers */,
 				70CA80141BDE4314000A3B21 /* AVImageRequestOperation.h in Headers */,
+				83331D4F1EB9A34000CADC9C /* AVDynamicObject_Internal.h in Headers */,
 				83FCB9A11CEDC57C007D8712 /* LCHTTPSessionManager.h in Headers */,
 				83FCB9CE1CEDC57C007D8712 /* LCURLResponseSerialization.h in Headers */,
 				70CA80151BDE4315000A3B21 /* AVJSONRequestOperation.h in Headers */,
@@ -3313,6 +3333,7 @@
 				70CA80391BDE4319000A3B21 /* AVReachability.h in Headers */,
 				70CA803A1BDE4319000A3B21 /* AVUtils.h in Headers */,
 				70CA803B1BDE4319000A3B21 /* UserAgent.h in Headers */,
+				83331D551EB9D55100CADC9C /* NSDictionary+LeanCloud.h in Headers */,
 				70CA803C1BDE4319000A3B21 /* LCDatabaseCommon.h in Headers */,
 				70CA803D1BDE4319000A3B21 /* LCDatabaseCoordinator.h in Headers */,
 				70CA803E1BDE431A000A3B21 /* LCDatabaseMigrator.h in Headers */,
@@ -3332,7 +3353,6 @@
 				70CA7FE51BDE42F5000A3B21 /* AVDuration.h in Headers */,
 				70CA7FE61BDE42F5000A3B21 /* AVExceptionHandler.h in Headers */,
 				70CA7FE81BDE42F6000A3B21 /* AVGlobal.h in Headers */,
-				83331D461EB9A25F00CADC9C /* AVCaptcha.h in Headers */,
 				9A404DD41CE5A9B700DEB3DC /* LCRouter.h in Headers */,
 				70CA7FE91BDE42F6000A3B21 /* AVOSCloud_Internal.h in Headers */,
 				70CA7FEB1BDE42F6000A3B21 /* AVCacheManager.h in Headers */,
@@ -3355,6 +3375,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				83331D481EB9A25F00CADC9C /* AVCaptcha.h in Headers */,
 				835092151EB1ECB7000DA884 /* AVDynamicObject.h in Headers */,
 				835092001EB1BDD0000DA884 /* AVSMS.h in Headers */,
 				8320F8D91C1918C60024B45E /* AVACL.h in Headers */,
@@ -3373,6 +3394,7 @@
 				8320F8EF1C1918C60024B45E /* AVObject+Subclass.h in Headers */,
 				8320F8F01C1918C60024B45E /* AVObject.h in Headers */,
 				8320F8F11C1918C60024B45E /* AVRelation.h in Headers */,
+				83331D571EB9D55100CADC9C /* NSDictionary+LeanCloud.h in Headers */,
 				83FCB9C61CEDC57C007D8712 /* LCURLRequestSerialization.h in Headers */,
 				8320F8F21C1918C60024B45E /* AVSubclassing.h in Headers */,
 				8320F8F31C1918C60024B45E /* AVInstallation.h in Headers */,
@@ -3387,7 +3409,6 @@
 				9A404DD61CE5A9BB00DEB3DC /* LCRouter.h in Headers */,
 				83FCB9DA1CEDC57C007D8712 /* LCURLSessionManager.h in Headers */,
 				8320F8F81C1918C60024B45E /* AVSearchQuery.h in Headers */,
-				83331D481EB9A25F00CADC9C /* AVCaptcha.h in Headers */,
 				83FCB9D01CEDC57C007D8712 /* LCURLResponseSerialization.h in Headers */,
 				8320F8FB1C1918C60024B45E /* LCDatabaseCoordinator.h in Headers */,
 				8320F8FC1C1918C60024B45E /* AVSearchSortBuilder.h in Headers */,
@@ -3402,6 +3423,7 @@
 				8320F9021C1918C60024B45E /* AVGlobal.h in Headers */,
 				8320F9031C1918C60024B45E /* AVFileHTTPRequestOperation.h in Headers */,
 				8320F9041C1918C60024B45E /* AVLocationManager.h in Headers */,
+				83331D511EB9A34000CADC9C /* AVDynamicObject_Internal.h in Headers */,
 				83BE73101D810651008ED3CF /* metamacros.h in Headers */,
 				830EB9C41C3E4BFA00BA917F /* LCObserver.h in Headers */,
 				83FCB9BC1CEDC57C007D8712 /* LCSecurityPolicy.h in Headers */,
@@ -3462,6 +3484,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				83331D471EB9A25F00CADC9C /* AVCaptcha.h in Headers */,
 				835092141EB1ECB7000DA884 /* AVDynamicObject.h in Headers */,
 				835091FF1EB1BDD0000DA884 /* AVSMS.h in Headers */,
 				83D8CED21C17DAF50094279D /* AVACL.h in Headers */,
@@ -3511,6 +3534,7 @@
 				83D8CEFD1C17DAF50094279D /* AVLocationManager.h in Headers */,
 				83D8CEFE1C17DAF50094279D /* AFNetworkingFix.h in Headers */,
 				83D8CF001C17DAF50094279D /* AVHTTPClient.h in Headers */,
+				83331D561EB9D55100CADC9C /* NSDictionary+LeanCloud.h in Headers */,
 				83D8CF011C17DAF50094279D /* AVHTTPRequestOperation.h in Headers */,
 				83D8CF021C17DAF50094279D /* AVImageRequestOperation.h in Headers */,
 				83D8CF031C17DAF50094279D /* AVJSONRequestOperation.h in Headers */,
@@ -3546,7 +3570,6 @@
 				83D8CF1E1C17DAF50094279D /* AVAckCommand.h in Headers */,
 				83D8CF201C17DAF50094279D /* SDMacros.h in Headers */,
 				830EB9C31C3E4BFA00BA917F /* LCObserver.h in Headers */,
-				83331D471EB9A25F00CADC9C /* AVCaptcha.h in Headers */,
 				83D8CF211C17DAF50094279D /* AVFriendQuery.h in Headers */,
 				83D8CF221C17DAF50094279D /* AVObject_Internal.h in Headers */,
 				83D8CF231C17DAF50094279D /* AVRelation_Internal.h in Headers */,
@@ -3569,6 +3592,7 @@
 				83D8CF331C17DAF50094279D /* AVSession_Internal.h in Headers */,
 				83D8CF341C17DAF50094279D /* AVUtils.h in Headers */,
 				83D8CF351C17DAF50094279D /* AVAnalyticsSession.h in Headers */,
+				83331D501EB9A34000CADC9C /* AVDynamicObject_Internal.h in Headers */,
 				83A2BD321CF33CDA0047B230 /* AVPaasClient_internal.h in Headers */,
 				83D8CF361C17DAF50094279D /* LCSSLChallenger.h in Headers */,
 				83D8CF371C17DAF50094279D /* AVScheduler.h in Headers */,
@@ -3634,6 +3658,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				83331D451EB9A25F00CADC9C /* AVCaptcha.h in Headers */,
 				835092121EB1ECB7000DA884 /* AVDynamicObject.h in Headers */,
 				835091FD1EB1BDD0000DA884 /* AVSMS.h in Headers */,
 				8C841AAD1A5A7A0000C5C6C4 /* AVACL.h in Headers */,
@@ -3683,6 +3708,7 @@
 				8C841B2F1A5A7A0000C5C6C4 /* AFNetworkingFix.h in Headers */,
 				8C841B3E1A5A7A0000C5C6C4 /* AVHTTPClient.h in Headers */,
 				8C841B401A5A7A0000C5C6C4 /* AVHTTPRequestOperation.h in Headers */,
+				83331D541EB9D55100CADC9C /* NSDictionary+LeanCloud.h in Headers */,
 				8C841B421A5A7A0000C5C6C4 /* AVImageRequestOperation.h in Headers */,
 				8C841B441A5A7A0000C5C6C4 /* AVJSONRequestOperation.h in Headers */,
 				8C841B461A5A7A0000C5C6C4 /* AVNetworkActivityIndicatorManager.h in Headers */,
@@ -3718,7 +3744,6 @@
 				830EB9C01C3E4BFA00BA917F /* LCObserver.h in Headers */,
 				8C841B2A1A5A7A0000C5C6C4 /* AVFriendQuery.h in Headers */,
 				8C841B1A1A5A7A0000C5C6C4 /* AVObject_Internal.h in Headers */,
-				83331D451EB9A25F00CADC9C /* AVCaptcha.h in Headers */,
 				8C841B1F1A5A7A0000C5C6C4 /* AVRelation_Internal.h in Headers */,
 				8C841AAF1A5A7A0000C5C6C4 /* AVACL_Internal.h in Headers */,
 				838DD7961B3D309F00C95897 /* LCNetworkStatistics.h in Headers */,
@@ -3741,6 +3766,7 @@
 				8C841B641A5A7A0000C5C6C4 /* AVUtils.h in Headers */,
 				83F9A2C71CE014430002E21B /* LCRouter.h in Headers */,
 				8C841ABA1A5A7A0000C5C6C4 /* AVAnalyticsSession.h in Headers */,
+				83331D4E1EB9A34000CADC9C /* AVDynamicObject_Internal.h in Headers */,
 				838DD7C21B42630400C95897 /* LCSSLChallenger.h in Headers */,
 				83FCB9B81CEDC57C007D8712 /* LCSecurityPolicy.h in Headers */,
 				8C841ACC1A5A7A0000C5C6C4 /* AVScheduler.h in Headers */,
@@ -4377,6 +4403,7 @@
 				70CA7F791BDE3721000A3B21 /* AVDuration.m in Sources */,
 				70CA7F7A1BDE3721000A3B21 /* AVExceptionHandler.m in Sources */,
 				70CA7F7B1BDE3721000A3B21 /* AVOSCloud.m in Sources */,
+				83331D591EB9D55100CADC9C /* NSDictionary+LeanCloud.m in Sources */,
 				70CA7F7C1BDE3721000A3B21 /* AVCacheManager.m in Sources */,
 				70CA7F7D1BDE3721000A3B21 /* AVPersistenceUtils.m in Sources */,
 				70CA7F7E1BDE3721000A3B21 /* AVScheduler.m in Sources */,
@@ -4514,6 +4541,7 @@
 				8320F8C51C1918C60024B45E /* AVRelation.m in Sources */,
 				9A404DE01CE5A9C400DEB3DC /* LCRouter.m in Sources */,
 				8320F8C71C1918C60024B45E /* AVFileHTTPRequestOperation.m in Sources */,
+				83331D5B1EB9D55100CADC9C /* NSDictionary+LeanCloud.m in Sources */,
 				8320F8C81C1918C60024B45E /* AVLogger.m in Sources */,
 				8320F8CA1C1918C60024B45E /* AVScheduler.m in Sources */,
 				830EB9C91C3E4BFA00BA917F /* LCObserver.m in Sources */,
@@ -4592,6 +4620,7 @@
 				83D8CEAD1C17DAF50094279D /* AVDirectOutCommand.m in Sources */,
 				83FCB9A71CEDC57C007D8712 /* LCHTTPSessionManager.m in Sources */,
 				83D8CEAF1C17DAF50094279D /* LCResultSet.m in Sources */,
+				83331D5A1EB9D55100CADC9C /* NSDictionary+LeanCloud.m in Sources */,
 				83D8CEB01C17DAF50094279D /* AVLocationManager.m in Sources */,
 				83FCB9CA1CEDC57C007D8712 /* LCURLRequestSerialization.m in Sources */,
 				83D8CEB11C17DAF50094279D /* AVStatus.m in Sources */,
@@ -4724,6 +4753,7 @@
 				8C841B081A5A7A0000C5C6C4 /* AVDirectOutCommand.m in Sources */,
 				83FCB9A41CEDC57C007D8712 /* LCHTTPSessionManager.m in Sources */,
 				83DF02BA1AF86032000E289C /* LCResultSet.m in Sources */,
+				83331D581EB9D55100CADC9C /* NSDictionary+LeanCloud.m in Sources */,
 				8C841AEB1A5A7A0000C5C6C4 /* AVLocationManager.m in Sources */,
 				83FCB9C71CEDC57C007D8712 /* LCURLRequestSerialization.m in Sources */,
 				8C841B3B1A5A7A0000C5C6C4 /* AVStatus.m in Sources */,

--- a/AVOS/AVOSCloud/AVOSCloud.h
+++ b/AVOS/AVOSCloud/AVOSCloud.h
@@ -56,6 +56,9 @@
 #import "AVACL.h"
 #import "AVRole.h"
 
+// Captcha
+#import "AVCaptcha.h"
+
 // SMS
 #import "AVSMS.h"
 

--- a/AVOS/AVOSCloud/AVOSCloud.h
+++ b/AVOS/AVOSCloud/AVOSCloud.h
@@ -228,53 +228,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)setFileCacheExpiredDays:(NSInteger)days;
 
 /*!
- *  请求短信验证码，需要开启手机短信验证 API 选项。
- *  发送短信到指定的手机上，发送短信到指定的手机上，获取6位数字验证码。
- *  @param phoneNumber 11位电话号码
- *  @param callback 回调结果
- */
-+(void)requestSmsCodeWithPhoneNumber:(NSString *)phoneNumber
-                            callback:(AVBooleanResultBlock)callback;
-/*!
- *  请求短信验证码，需要开启手机短信验证 API 选项。
- *  发送短信到指定的手机上，获取6位数字验证码。
- *  @param phoneNumber 11位电话号码
- *  @param appName 应用名称，传nil为默认值您的应用名称
- *  @param operation 操作名称，传nil为默认值"短信认证"
- *  @param ttl 短信过期时间，单位分钟，传0为默认值10分钟
- *  @param callback 回调结果
- */
-+(void)requestSmsCodeWithPhoneNumber:(NSString *)phoneNumber
-                             appName:(nullable NSString *)appName
-                           operation:(nullable NSString *)operation
-                          timeToLive:(NSUInteger)ttl
-                            callback:(AVBooleanResultBlock)callback;
-
-/*!
- *  请求短信验证码，需要开启手机短信验证 API 选项。
- *  发送短信到指定的手机上，获取6位数字验证码。
- *  @param phoneNumber 11位电话号码
- *  @param templateName 模板名称，传nil为默认模板
- *  @param variables 模板中使用的变量
- *  @param callback 回调结果
- */
-+(void)requestSmsCodeWithPhoneNumber:(NSString *)phoneNumber
-                        templateName:(nullable NSString *)templateName
-                           variables:(nullable NSDictionary *)variables
-                            callback:(AVBooleanResultBlock)callback;
-
-/*!
- * 请求语音短信验证码，需要开启手机短信验证 API 选项
- * 发送语音短信到指定手机上
- * @param phoneNumber 11 位电话号码
- * @param IDD 号码的所在地国家代码，如果传 nil，默认为 "+86"
- * @param callback 回调结果
- */
-+(void)requestVoiceCodeWithPhoneNumber:(NSString *)phoneNumber
-                                   IDD:(nullable NSString *)IDD
-                              callback:(AVBooleanResultBlock)callback;
-
-/*!
  *  验证短信验证码，需要开启手机短信验证 API 选项。
  *  发送验证码给服务器进行验证。
  *  @param code 6位手机验证码
@@ -349,6 +302,54 @@ NS_ASSUME_NONNULL_BEGIN
  * Use LeanCloud China Sever. Default option.
  */
 + (void)useAVCloudCN AV_DEPRECATED("Deprecated in AVOSCloud SDK 3.2.3. Use +[AVOSCloud setServiceRegion:] instead.");
+
+/*!
+ *  请求短信验证码，需要开启手机短信验证 API 选项。
+ *  发送短信到指定的手机上，发送短信到指定的手机上，获取6位数字验证码。
+ *  @param phoneNumber 11位电话号码
+ *  @param callback 回调结果
+ */
++(void)requestSmsCodeWithPhoneNumber:(NSString *)phoneNumber
+                            callback:(AVBooleanResultBlock)callback AV_DEPRECATED("Deprecated in AVOSCloud SDK 4.5.0. Use +[AVSMS requestShortMessageForPhoneNumber:options:callback:] instead.");
+
+/*!
+ *  请求短信验证码，需要开启手机短信验证 API 选项。
+ *  发送短信到指定的手机上，获取6位数字验证码。
+ *  @param phoneNumber 11位电话号码
+ *  @param appName 应用名称，传nil为默认值您的应用名称
+ *  @param operation 操作名称，传nil为默认值"短信认证"
+ *  @param ttl 短信过期时间，单位分钟，传0为默认值10分钟
+ *  @param callback 回调结果
+ */
++(void)requestSmsCodeWithPhoneNumber:(NSString *)phoneNumber
+                             appName:(nullable NSString *)appName
+                           operation:(nullable NSString *)operation
+                          timeToLive:(NSUInteger)ttl
+                            callback:(AVBooleanResultBlock)callback AV_DEPRECATED("Deprecated in AVOSCloud SDK 4.5.0. Use +[AVSMS requestShortMessageForPhoneNumber:options:callback:] instead.");
+
+/*!
+ *  请求短信验证码，需要开启手机短信验证 API 选项。
+ *  发送短信到指定的手机上，获取6位数字验证码。
+ *  @param phoneNumber 11位电话号码
+ *  @param templateName 模板名称，传nil为默认模板
+ *  @param variables 模板中使用的变量
+ *  @param callback 回调结果
+ */
++(void)requestSmsCodeWithPhoneNumber:(NSString *)phoneNumber
+                        templateName:(nullable NSString *)templateName
+                           variables:(nullable NSDictionary *)variables
+                            callback:(AVBooleanResultBlock)callback AV_DEPRECATED("Deprecated in AVOSCloud SDK 4.5.0. Use +[AVSMS requestShortMessageForPhoneNumber:options:callback:] instead.");
+
+/*!
+ * 请求语音短信验证码，需要开启手机短信验证 API 选项
+ * 发送语音短信到指定手机上
+ * @param phoneNumber 11 位电话号码
+ * @param IDD 号码的所在地国家代码，如果传 nil，默认为 "+86"
+ * @param callback 回调结果
+ */
++(void)requestVoiceCodeWithPhoneNumber:(NSString *)phoneNumber
+                                   IDD:(nullable NSString *)IDD
+                              callback:(AVBooleanResultBlock)callback AV_DEPRECATED("Deprecated in AVOSCloud SDK 4.5.0. Use +[AVSMS requestShortMessageForPhoneNumber:options:callback:] instead.");
 
 @end
 

--- a/AVOS/AVOSCloud/AVOSCloud.h
+++ b/AVOS/AVOSCloud/AVOSCloud.h
@@ -56,10 +56,7 @@
 #import "AVACL.h"
 #import "AVRole.h"
 
-// Captcha
 #import "AVCaptcha.h"
-
-// SMS
 #import "AVSMS.h"
 
 #if AV_IOS_ONLY && !TARGET_OS_WATCH

--- a/AVOS/AVOSCloud/AVOSCloud.h
+++ b/AVOS/AVOSCloud/AVOSCloud.h
@@ -56,6 +56,9 @@
 #import "AVACL.h"
 #import "AVRole.h"
 
+// SMS
+#import "AVSMS.h"
+
 #if AV_IOS_ONLY && !TARGET_OS_WATCH
 // IM 1.0
 #import "AVSession.h"

--- a/AVOS/AVOSCloud/AVOSCloud.m
+++ b/AVOS/AVOSCloud/AVOSCloud.m
@@ -347,10 +347,6 @@ static AVLogLevel avlogLevel = AVLogLevelDefault;
     }];
 }
 
-+(void)verifySmsCode:(NSString *)code callback:(AVBooleanResultBlock)callback {
-    @throw [NSException exceptionWithName:@"Interface not supported" reason:@"This interface is altered by +[verifySmsCode:mobilePhoneNumber:callback:]" userInfo:nil];
-}
-
 +(void)verifySmsCode:(NSString *)code mobilePhoneNumber:(NSString *)phoneNumber callback:(AVBooleanResultBlock)callback {
     NSParameterAssert(code);
     NSParameterAssert(phoneNumber);

--- a/AVOS/AVOSCloud/Captcha/AVCaptcha.h
+++ b/AVOS/AVOSCloud/Captcha/AVCaptcha.h
@@ -7,7 +7,69 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "AVDynamicObject.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AVCaptchaInformation : AVDynamicObject
+
+/**
+ Token used to verify captcha.
+ */
+@property (nonatomic, copy, readonly) NSString *token;
+
+/**
+ URL string of captcha image.
+ */
+@property (nonatomic, copy, readonly) NSString *URLString;
+
+@end
+
+@interface AVCaptchaRequestOptions : AVDynamicObject
+
+/**
+ Time to live of captcha, in seconds.
+
+ Defaults to 60 seconds. Minimum is 10, maximum is 180.
+ */
+@property (nonatomic, assign) NSInteger TTL;
+
+/**
+ Count of characters in catpcha image.
+
+ Defaults to 4. Minimum is 3, maximum is 6.
+ */
+@property (nonatomic, assign) NSInteger size;
+
+/**
+ Width of captcha image, in pixels.
+
+ Defaults to 85. Minimum is 85, maximum is 200.
+ */
+@property (nonatomic, assign) NSInteger width;
+
+/**
+ Height of captcha image, in pixels.
+
+ Defaults to 30. Minimum is 30, maximum is 100.
+ */
+@property (nonatomic, assign) NSInteger height;
+
+@end
+
+typedef void(^AVCaptchaRequestCallback)(AVCaptchaInformation * _Nullable captchaInformation, NSError * _Nullable error);
 
 @interface AVCaptcha : NSObject
 
+/**
+ Request a captcha.
+
+ @param options  The options that configure the captcha.
+ @param callback The callback of request.
+ */
++ (void)requestCaptchaWithOptions:(nullable AVCaptchaRequestOptions *)options
+                         callback:(AVCaptchaRequestCallback)callback;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AVOS/AVOSCloud/Captcha/AVCaptcha.h
+++ b/AVOS/AVOSCloud/Captcha/AVCaptcha.h
@@ -76,6 +76,7 @@ typedef void(^AVCaptchaVerificationCallback)(NSString * _Nullable validationToke
 
  @param captchaCode  The symbols user recognized from captcha image.
  @param captchaToken The token that you requested before.
+ @param callback     The callback of request.
  */
 + (void)verifyCaptchaCode:(NSString *)captchaCode
           forCaptchaToken:(NSString *)captchaToken

--- a/AVOS/AVOSCloud/Captcha/AVCaptcha.h
+++ b/AVOS/AVOSCloud/Captcha/AVCaptcha.h
@@ -1,0 +1,13 @@
+//
+//  AVCaptcha.h
+//  AVOS
+//
+//  Created by Tang Tianyong on 03/05/2017.
+//  Copyright © 2017 LeanCloud Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface AVCaptcha : NSObject
+
+@end

--- a/AVOS/AVOSCloud/Captcha/AVCaptcha.h
+++ b/AVOS/AVOSCloud/Captcha/AVCaptcha.h
@@ -58,6 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 typedef void(^AVCaptchaRequestCallback)(AVCaptchaInformation * _Nullable captchaInformation, NSError * _Nullable error);
+typedef void(^AVCaptchaVerificationCallback)(NSString * _Nullable validationToken, NSError * _Nullable error);
 
 @interface AVCaptcha : NSObject
 
@@ -69,6 +70,16 @@ typedef void(^AVCaptchaRequestCallback)(AVCaptchaInformation * _Nullable captcha
  */
 + (void)requestCaptchaWithOptions:(nullable AVCaptchaRequestOptions *)options
                          callback:(AVCaptchaRequestCallback)callback;
+
+/**
+ Verify a captcha code for captcha token that you've requested before.
+
+ @param captchaCode  The symbols user recognized from captcha image.
+ @param captchaToken The token that you requested before.
+ */
++ (void)verifyCaptchaCode:(NSString *)captchaCode
+          forCaptchaToken:(NSString *)captchaToken
+                 callback:(AVCaptchaVerificationCallback)callback;
 
 @end
 

--- a/AVOS/AVOSCloud/Captcha/AVCaptcha.h
+++ b/AVOS/AVOSCloud/Captcha/AVCaptcha.h
@@ -11,12 +11,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface AVCaptchaInformation : AVDynamicObject
+@interface AVCaptchaDigest : AVDynamicObject
 
 /**
- Token used to verify captcha.
+ A nonce used to verify captcha.
  */
-@property (nonatomic, copy, readonly) NSString *token;
+@property (nonatomic, copy, readonly) NSString *nonce;
 
 /**
  URL string of captcha image.
@@ -57,13 +57,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-typedef void(^AVCaptchaRequestCallback)(AVCaptchaInformation * _Nullable captchaInformation, NSError * _Nullable error);
+typedef void(^AVCaptchaRequestCallback)(AVCaptchaDigest * _Nullable captchaDigest, NSError * _Nullable error);
 typedef void(^AVCaptchaVerificationCallback)(NSString * _Nullable validationToken, NSError * _Nullable error);
 
 @interface AVCaptcha : NSObject
 
 /**
  Request a captcha.
+
+ This method get a captcha digest from server.
+ You can use the captcha digest to verify a captcha code that recognized by user.
 
  @param options  The options that configure the captcha.
  @param callback The callback of request.
@@ -72,14 +75,14 @@ typedef void(^AVCaptchaVerificationCallback)(NSString * _Nullable validationToke
                          callback:(AVCaptchaRequestCallback)callback;
 
 /**
- Verify a captcha code for captcha token that you've requested before.
+ Verify a captcha code for captcha digest that you've requested before.
 
- @param captchaCode  The symbols user recognized from captcha image.
- @param captchaToken The token that you requested before.
- @param callback     The callback of request.
+ @param captchaCode   The symbols user recognized from captcha image.
+ @param captchaDigest The captcha digest that you've requested before.
+ @param callback      The callback of request.
  */
 + (void)verifyCaptchaCode:(NSString *)captchaCode
-          forCaptchaToken:(NSString *)captchaToken
+         forCaptchaDigest:(AVCaptchaDigest *)captchaDigest
                  callback:(AVCaptchaVerificationCallback)callback;
 
 @end

--- a/AVOS/AVOSCloud/Captcha/AVCaptcha.m
+++ b/AVOS/AVOSCloud/Captcha/AVCaptcha.m
@@ -61,6 +61,9 @@
           forCaptchaToken:(NSString *)captchaToken
                  callback:(AVCaptchaVerificationCallback)callback
 {
+    NSParameterAssert(captchaCode);
+    NSParameterAssert(captchaToken);
+
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
 
     parameters[@"captcha_code"]  = captchaCode;

--- a/AVOS/AVOSCloud/Captcha/AVCaptcha.m
+++ b/AVOS/AVOSCloud/Captcha/AVCaptcha.m
@@ -12,9 +12,9 @@
 #import "AVPaasClient.h"
 #import "AVUtils.h"
 
-@implementation AVCaptchaInformation
+@implementation AVCaptchaDigest
 
-@dynamic token;
+@dynamic nonce;
 @dynamic URLString;
 
 @end
@@ -47,27 +47,27 @@
         }
 
         NSDictionary *dictionary = [object lc_selectEntriesWithKeyMappings:@{
-            @"captcha_token" : @"token",
+            @"captcha_token" : @"nonce",
             @"captcha_url"   : @"URLString"
         }];
 
-        AVCaptchaInformation *captchaInformation = [[AVCaptchaInformation alloc] initWithDictionary:dictionary];
+        AVCaptchaDigest *captchaDigest = [[AVCaptchaDigest alloc] initWithDictionary:dictionary];
 
-        [AVUtils callIdResultBlock:callback object:captchaInformation error:nil];
+        [AVUtils callIdResultBlock:callback object:captchaDigest error:nil];
     }];
 }
 
 + (void)verifyCaptchaCode:(NSString *)captchaCode
-          forCaptchaToken:(NSString *)captchaToken
+         forCaptchaDigest:(AVCaptchaDigest *)captchaDigest
                  callback:(AVCaptchaVerificationCallback)callback
 {
     NSParameterAssert(captchaCode);
-    NSParameterAssert(captchaToken);
+    NSParameterAssert(captchaDigest);
 
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
 
     parameters[@"captcha_code"]  = captchaCode;
-    parameters[@"captcha_token"] = captchaToken;
+    parameters[@"captcha_token"] = captchaDigest.nonce;
 
     [[AVPaasClient sharedInstance] postObject:@"verifyCaptcha" withParameters:parameters block:^(id object, NSError *error) {
         if (error) {

--- a/AVOS/AVOSCloud/Captcha/AVCaptcha.m
+++ b/AVOS/AVOSCloud/Captcha/AVCaptcha.m
@@ -58,4 +58,25 @@
     }];
 }
 
++ (void)verifyCaptchaCode:(NSString *)captchaCode
+          forCaptchaToken:(NSString *)captchaToken
+                 callback:(AVCaptchaVerificationCallback)callback
+{
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+
+    parameters[@"captcha_code"]  = captchaCode;
+    parameters[@"captcha_token"] = captchaToken;
+
+    [[AVPaasClient sharedInstance] postObject:@"verifyCaptcha" withParameters:parameters block:^(id object, NSError *error) {
+        if (error) {
+            [AVUtils callIdResultBlock:callback object:object error:error];
+            return;
+        }
+
+        NSString *validationToken = object[@"validate_token"];
+
+        [AVUtils callIdResultBlock:callback object:validationToken error:nil];
+    }];
+}
+
 @end

--- a/AVOS/AVOSCloud/Captcha/AVCaptcha.m
+++ b/AVOS/AVOSCloud/Captcha/AVCaptcha.m
@@ -33,13 +33,12 @@
 + (void)requestCaptchaWithOptions:(AVCaptchaRequestOptions *)options
                          callback:(AVCaptchaRequestCallback)callback
 {
-    NSDictionary *optionTable = options.properties;
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
 
-    parameters[@"ttl"]    = optionTable[@"TTL"];
-    parameters[@"size"]   = optionTable[@"size"];
-    parameters[@"width"]  = optionTable[@"width"];
-    parameters[@"height"] = optionTable[@"height"];
+    parameters[@"ttl"]    = options[@"TTL"];
+    parameters[@"size"]   = options[@"size"];
+    parameters[@"width"]  = options[@"width"];
+    parameters[@"height"] = options[@"height"];
 
     [[AVPaasClient sharedInstance] getObject:@"requestCaptcha" withParameters:parameters block:^(id object, NSError *error) {
         if (error) {

--- a/AVOS/AVOSCloud/Captcha/AVCaptcha.m
+++ b/AVOS/AVOSCloud/Captcha/AVCaptcha.m
@@ -1,0 +1,13 @@
+//
+//  AVCaptcha.m
+//  AVOS
+//
+//  Created by Tang Tianyong on 03/05/2017.
+//  Copyright © 2017 LeanCloud Inc. All rights reserved.
+//
+
+#import "AVCaptcha.h"
+
+@implementation AVCaptcha
+
+@end

--- a/AVOS/AVOSCloud/SMS/AVSMS.h
+++ b/AVOS/AVOSCloud/SMS/AVSMS.h
@@ -7,7 +7,43 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "AVDynamicObject.h"
+#import "AVConstants.h"
+
+@interface AVShortMessageRequestOptions : AVDynamicObject
+
+/// Time to live of short message, in minutes.
+@property (nonatomic, assign) NSInteger TTL;
+
+/// Type of short message. Currently support two types: "voice" and "sms", defaults to "sms".
+@property (nonatomic, copy) NSString *type;
+
+/// Template of short message.
+@property (nonatomic, copy) NSString *template;
+
+/// Signature of short message template.
+@property (nonatomic, copy) NSString *signature;
+
+/// Application name displayed in short message. If not given, the application name in console will be used.
+@property (nonatomic, copy) NSString *applicationName;
+
+/// Operation name of short message.
+@property (nonatomic, copy) NSString *operationName;
+
+@end
+
 
 @interface AVSMS : NSObject
+
+/**
+ Request a short message for a phone number.
+
+ @param phoneNumber The phone number which the short message will sent to.
+ @param options     The options that configure short message.
+ @param callback    The callback of request.
+ */
++ (void)requestShortMessageForPhoneNumber:(NSString *)phoneNumber
+                                  options:(AVShortMessageRequestOptions *)options
+                                 callback:(AVBooleanResultBlock)callback;
 
 @end

--- a/AVOS/AVOSCloud/SMS/AVSMS.h
+++ b/AVOS/AVOSCloud/SMS/AVSMS.h
@@ -10,25 +10,64 @@
 #import "AVDynamicObject.h"
 #import "AVConstants.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Enumeration of short message types.
+ */
+typedef NS_ENUM(NSInteger, AVShortMessageType) {
+    AVShortMessageTypeText = 0,
+    AVShortMessageTypeVoice
+};
+
 @interface AVShortMessageRequestOptions : AVDynamicObject
 
-/// Time to live of short message, in minutes.
+/**
+ Time to live of validation information, in minutes. Defaults to 10 minutes.
+ */
 @property (nonatomic, assign) NSInteger TTL;
 
-/// Type of short message. Currently support two types: "voice" and "sms", defaults to "sms".
-@property (nonatomic, copy) NSString *type;
+/**
+ The representation or form of short message.
+ */
+@property (nonatomic, assign) AVShortMessageType type;
 
-/// Template of short message.
-@property (nonatomic, copy) NSString *template;
+/**
+ Template name of text short message.
 
-/// Signature of short message template.
-@property (nonatomic, copy) NSString *signature;
+ @note If not specified, the default validation message will be requested.
+ */
+@property (nonatomic, copy, nullable) NSString *templateName;
 
-/// Application name displayed in short message. If not given, the application name in console will be used.
-@property (nonatomic, copy) NSString *applicationName;
+/**
+ A set of key value pairs that will fill in template placeholders.
 
-/// Operation name of short message.
-@property (nonatomic, copy) NSString *operationName;
+ @note You should not use the placeholders listed here in your template:
+ `mobilePhoneNumber`, `ttl`, `smsType`, `template` and `sign`.
+ */
+@property (nonatomic, strong, nullable) NSDictionary *templateVariables;
+
+/**
+ Signature name of text short message.
+
+ It will be placed ahead of text short message.
+ */
+@property (nonatomic, copy, nullable) NSString *signatureName;
+
+/**
+ Application name showed in validation message.
+
+ It fills the placeholder <code>{{name}}</code> in default validation message template.
+ If not given, the application name in LeanCloud console will be used.
+ */
+@property (nonatomic, copy, nullable) NSString *applicationName;
+
+/**
+ The operation description showed in validation message.
+
+ It fills the placeholder <code>{{op}}</code> in default validation message template.
+ */
+@property (nonatomic, copy, nullable) NSString *operation;
 
 @end
 
@@ -43,7 +82,9 @@
  @param callback    The callback of request.
  */
 + (void)requestShortMessageForPhoneNumber:(NSString *)phoneNumber
-                                  options:(AVShortMessageRequestOptions *)options
+                                  options:(nullable AVShortMessageRequestOptions *)options
                                  callback:(AVBooleanResultBlock)callback;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AVOS/AVOSCloud/SMS/AVSMS.h
+++ b/AVOS/AVOSCloud/SMS/AVSMS.h
@@ -1,0 +1,13 @@
+//
+//  AVSMS.h
+//  AVOS
+//
+//  Created by Tang Tianyong on 27/04/2017.
+//  Copyright © 2017 LeanCloud Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface AVSMS : NSObject
+
+@end

--- a/AVOS/AVOSCloud/SMS/AVSMS.h
+++ b/AVOS/AVOSCloud/SMS/AVSMS.h
@@ -33,6 +33,11 @@ typedef NS_ENUM(NSInteger, AVShortMessageType) {
 @property (nonatomic, assign) AVShortMessageType type;
 
 /**
+ Token used to validate short message request.
+ */
+@property (nonatomic, copy, nullable) NSString *validationToken;
+
+/**
  Template name of text short message.
 
  @note If not specified, the default validation message will be requested.

--- a/AVOS/AVOSCloud/SMS/AVSMS.m
+++ b/AVOS/AVOSCloud/SMS/AVSMS.m
@@ -1,0 +1,13 @@
+//
+//  AVSMS.m
+//  AVOS
+//
+//  Created by Tang Tianyong on 27/04/2017.
+//  Copyright © 2017 LeanCloud Inc. All rights reserved.
+//
+
+#import "AVSMS.h"
+
+@implementation AVSMS
+
+@end

--- a/AVOS/AVOSCloud/SMS/AVSMS.m
+++ b/AVOS/AVOSCloud/SMS/AVSMS.m
@@ -7,7 +7,41 @@
 //
 
 #import "AVSMS.h"
+#import "AVPaasClient.h"
+#import "AVUtils.h"
+
+@implementation AVShortMessageRequestOptions
+
+@dynamic TTL;
+@dynamic type;
+@dynamic template;
+@dynamic signature;
+@dynamic applicationName;
+@dynamic operationName;
+
+@end
 
 @implementation AVSMS
+
++ (void)requestShortMessageForPhoneNumber:(NSString *)phoneNumber
+                                  options:(AVShortMessageRequestOptions *)options
+                                 callback:(AVBooleanResultBlock)callback
+{
+    NSParameterAssert(phoneNumber);
+
+    NSMutableDictionary *parameters = [[NSMutableDictionary alloc] init];
+
+    parameters[@"mobilePhoneNumber"] = phoneNumber;
+    parameters[@"ttl"]               = @(options.TTL);
+    parameters[@"smsType"]           = options.type;
+    parameters[@"template"]          = options.template;
+    parameters[@"sign"]              = options.signature;
+    parameters[@"name"]              = options.applicationName;
+    parameters[@"op"]                = options.operationName;
+
+    [[AVPaasClient sharedInstance] postObject:@"requestSmsCode" withParameters:parameters block:^(id object, NSError *error) {
+        [AVUtils callBooleanResultBlock:callback error:error];
+    }];
+}
 
 @end

--- a/AVOS/AVOSCloud/SMS/AVSMS.m
+++ b/AVOS/AVOSCloud/SMS/AVSMS.m
@@ -9,6 +9,13 @@
 #import "AVSMS.h"
 #import "AVPaasClient.h"
 #import "AVUtils.h"
+#import "AVDynamicObject_Internal.h"
+
+@interface AVShortMessageRequestOptions ()
+
+@property (nonatomic, copy, readonly) NSString *typeDescription;
+
+@end
 
 @implementation AVShortMessageRequestOptions
 
@@ -20,12 +27,8 @@
 @dynamic applicationName;
 @dynamic operation;
 
-@end
-
-@implementation AVSMS
-
-+ (NSString *)shortMessageTypeString:(AVShortMessageType)type {
-    switch (type) {
+- (NSString *)typeDescription {
+    switch (self.type) {
     case AVShortMessageTypeText:
         return @"sms";
     case AVShortMessageTypeVoice:
@@ -34,6 +37,10 @@
 
     return nil;
 }
+
+@end
+
+@implementation AVSMS
 
 + (void)requestShortMessageForPhoneNumber:(NSString *)phoneNumber
                                   options:(AVShortMessageRequestOptions *)options
@@ -52,8 +59,8 @@
     }
 
     parameters[@"mobilePhoneNumber"] = phoneNumber;
-    parameters[@"ttl"]               = @(options.TTL);
-    parameters[@"smsType"]           = [self shortMessageTypeString:options.type];
+    parameters[@"ttl"]               = options[@"TTL"];
+    parameters[@"smsType"]           = options.typeDescription;
     parameters[@"validate_token"]    = options.validationToken;
     parameters[@"template"]          = options.templateName;
     parameters[@"sign"]              = options.signatureName;

--- a/AVOS/AVOSCloud/SMS/AVSMS.m
+++ b/AVOS/AVOSCloud/SMS/AVSMS.m
@@ -43,6 +43,14 @@
 
     NSMutableDictionary *parameters = [[NSMutableDictionary alloc] init];
 
+    NSDictionary *templateVariables = options.templateVariables;
+
+    if (templateVariables) {
+        /* Template variables and message options are twisted together.
+           It's a deficiency of REST API, and it should be improved in future. */
+        [parameters addEntriesFromDictionary:templateVariables];
+    }
+
     parameters[@"mobilePhoneNumber"] = phoneNumber;
     parameters[@"ttl"]               = @(options.TTL);
     parameters[@"smsType"]           = [self shortMessageTypeString:options.type];

--- a/AVOS/AVOSCloud/SMS/AVSMS.m
+++ b/AVOS/AVOSCloud/SMS/AVSMS.m
@@ -14,14 +14,26 @@
 
 @dynamic TTL;
 @dynamic type;
-@dynamic template;
-@dynamic signature;
+@dynamic templateName;
+@dynamic templateVariables;
+@dynamic signatureName;
 @dynamic applicationName;
-@dynamic operationName;
+@dynamic operation;
 
 @end
 
 @implementation AVSMS
+
++ (NSString *)shortMessageTypeString:(AVShortMessageType)type {
+    switch (type) {
+    case AVShortMessageTypeText:
+        return @"sms";
+    case AVShortMessageTypeVoice:
+        return @"voice";
+    }
+
+    return nil;
+}
 
 + (void)requestShortMessageForPhoneNumber:(NSString *)phoneNumber
                                   options:(AVShortMessageRequestOptions *)options
@@ -33,11 +45,11 @@
 
     parameters[@"mobilePhoneNumber"] = phoneNumber;
     parameters[@"ttl"]               = @(options.TTL);
-    parameters[@"smsType"]           = options.type;
-    parameters[@"template"]          = options.template;
-    parameters[@"sign"]              = options.signature;
+    parameters[@"smsType"]           = [self shortMessageTypeString:options.type];
+    parameters[@"template"]          = options.templateName;
+    parameters[@"sign"]              = options.signatureName;
     parameters[@"name"]              = options.applicationName;
-    parameters[@"op"]                = options.operationName;
+    parameters[@"op"]                = options.operation;
 
     [[AVPaasClient sharedInstance] postObject:@"requestSmsCode" withParameters:parameters block:^(id object, NSError *error) {
         [AVUtils callBooleanResultBlock:callback error:error];

--- a/AVOS/AVOSCloud/SMS/AVSMS.m
+++ b/AVOS/AVOSCloud/SMS/AVSMS.m
@@ -54,6 +54,7 @@
     parameters[@"mobilePhoneNumber"] = phoneNumber;
     parameters[@"ttl"]               = @(options.TTL);
     parameters[@"smsType"]           = [self shortMessageTypeString:options.type];
+    parameters[@"validate_token"]    = options.validationToken;
     parameters[@"template"]          = options.templateName;
     parameters[@"sign"]              = options.signatureName;
     parameters[@"name"]              = options.applicationName;

--- a/AVOS/AVOSCloud/User/AVUser.h
+++ b/AVOS/AVOSCloud/User/AVUser.h
@@ -5,9 +5,11 @@
 #import "AVConstants.h"
 #import "AVObject.h"
 #import "AVSubclassing.h"
+#import "AVDynamicObject.h"
 
 @class AVRole;
 @class AVQuery;
+@class AVUserShortMessageRequestOptions;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -113,6 +115,17 @@ A LeanCloud Framework User Object that is a local representation of a user persi
  *  @param block 回调结果
  */
 +(void)requestMobilePhoneVerify:(NSString *)phoneNumber withBlock:(AVBooleanResultBlock)block;
+
+/**
+ Request a verification code for a phone number.
+
+ @param phoneNumber The phone number that will be verified later.
+ @param options     The short message request options.
+ @param callback    The callback of request.
+ */
++ (void)requestVerificationCodeForPhoneNumber:(NSString *)phoneNumber
+                                      options:(nullable AVUserShortMessageRequestOptions *)options
+                                     callback:(AVBooleanResultBlock)callback;
 
 /*!
  *  验证手机验证码
@@ -226,6 +239,17 @@ A LeanCloud Framework User Object that is a local representation of a user persi
  */
 +(void)requestLoginSmsCode:(NSString *)phoneNumber withBlock:(AVBooleanResultBlock)block;
 
+/**
+ Request a login code for a phone number.
+
+ @param phoneNumber The phone number of an user who will login later.
+ @param options     The short message request options.
+ @param callback    The callback of request.
+ */
++ (void)requestLoginCodeForPhoneNumber:(NSString *)phoneNumber
+                               options:(nullable AVUserShortMessageRequestOptions *)options
+                              callback:(AVBooleanResultBlock)callback;
+
 /*!
  *  使用手机号码和验证码登录
  *  @param phoneNumber 11位电话号码
@@ -310,6 +334,17 @@ A LeanCloud Framework User Object that is a local representation of a user persi
 +(void)requestPasswordResetWithPhoneNumber:(NSString *)phoneNumber
                                      block:(AVBooleanResultBlock)block;
 
+/**
+ Request a password reset code for a phone number.
+
+ @param phoneNumber The phone number of an user whose password will be reset.
+ @param options     The short message request options.
+ @param callback    The callback of request.
+ */
++ (void)requestPasswordResetCodeForPhoneNumber:(NSString *)phoneNumber
+                                       options:(nullable AVUserShortMessageRequestOptions *)options
+                                      callback:(AVBooleanResultBlock)callback;
+
 /*!
  *  使用验证码重置密码
  *  @param code 6位验证码
@@ -340,6 +375,13 @@ A LeanCloud Framework User Object that is a local representation of a user persi
  Creates a query for AVUser objects.
  */
 + (AVQuery *)query;
+
+@end
+
+@interface AVUserShortMessageRequestOptions : AVDynamicObject
+
+@property (nonatomic, copy, nullable) NSString *validationToken;
+
 @end
 
 @interface AVUser (Deprecated)

--- a/AVOS/AVOSCloud/User/AVUser.m
+++ b/AVOS/AVOSCloud/User/AVUser.m
@@ -273,11 +273,22 @@ static BOOL enableAutomatic = NO;
     }];
 }
 
-+(void)requestMobilePhoneVerify:(NSString *)phoneNumber withBlock:(AVBooleanResultBlock)block {
++ (void)requestMobilePhoneVerify:(NSString *)phoneNumber withBlock:(AVBooleanResultBlock)block {
+    [self requestVerificationCodeForPhoneNumber:phoneNumber options:nil callback:block];
+}
+
++ (void)requestVerificationCodeForPhoneNumber:(NSString *)phoneNumber
+                                      options:(AVUserShortMessageRequestOptions *)options
+                                     callback:(AVBooleanResultBlock)callback
+{
     NSParameterAssert(phoneNumber);
-    
-    [[AVPaasClient sharedInstance] postObject:@"requestMobilePhoneVerify" withParameters:@{ @"mobilePhoneNumber" : phoneNumber } block:^(id object, NSError *error) {
-        [AVUtils callBooleanResultBlock:block error:error];
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+
+    parameters[@"mobilePhoneNumber"] = phoneNumber;
+    parameters[@"validate_token"] = options.validationToken;
+
+    [[AVPaasClient sharedInstance] postObject:@"requestMobilePhoneVerify" withParameters:parameters block:^(id object, NSError *error) {
+        [AVUtils callBooleanResultBlock:callback error:error];
     }];
 }
 
@@ -568,11 +579,22 @@ static BOOL enableAutomatic = NO;
     return user;
 }
 
-+(void)requestLoginSmsCode:(NSString *)phoneNumber withBlock:(AVBooleanResultBlock)block {
++ (void)requestLoginSmsCode:(NSString *)phoneNumber withBlock:(AVBooleanResultBlock)block {
+    [self requestLoginCodeForPhoneNumber:phoneNumber options:nil callback:block];
+}
+
++ (void)requestLoginCodeForPhoneNumber:(NSString *)phoneNumber
+                               options:(AVUserShortMessageRequestOptions *)options
+                              callback:(AVBooleanResultBlock)callback
+{
     NSParameterAssert(phoneNumber);
-    
-    [[AVPaasClient sharedInstance] postObject:@"requestLoginSmsCode" withParameters:@{ @"mobilePhoneNumber" : phoneNumber } block:^(id object, NSError *error) {
-        [AVUtils callBooleanResultBlock:block error:error];
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+
+    parameters[@"mobilePhoneNumber"] = phoneNumber;
+    parameters[@"validate_token"] = options.validationToken;
+
+    [[AVPaasClient sharedInstance] postObject:@"requestLoginSmsCode" withParameters:parameters block:^(id object, NSError *error) {
+        [AVUtils callBooleanResultBlock:callback error:error];
     }];
 }
 
@@ -814,11 +836,22 @@ static BOOL enableAutomatic = NO;
     }];
 }
 
-+(void)requestPasswordResetWithPhoneNumber:(NSString *)phoneNumber block:(AVBooleanResultBlock)block {
++ (void)requestPasswordResetWithPhoneNumber:(NSString *)phoneNumber block:(AVBooleanResultBlock)block {
+    [self requestPasswordResetCodeForPhoneNumber:phoneNumber options:nil callback:block];
+}
+
++ (void)requestPasswordResetCodeForPhoneNumber:(NSString *)phoneNumber
+                                       options:(AVUserShortMessageRequestOptions *)options
+                                      callback:(AVBooleanResultBlock)callback
+{
     NSParameterAssert(phoneNumber);
-    
-    [[AVPaasClient sharedInstance] postObject:@"requestPasswordResetBySmsCode" withParameters:@{ @"mobilePhoneNumber" : phoneNumber } block:^(id object, NSError *error) {
-        [AVUtils callBooleanResultBlock:block error:error];
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+
+    parameters[@"mobilePhoneNumber"] = phoneNumber;
+    parameters[@"validate_token"] = options.validationToken;
+
+    [[AVPaasClient sharedInstance] postObject:@"requestPasswordResetBySmsCode" withParameters:parameters block:^(id object, NSError *error) {
+        [AVUtils callBooleanResultBlock:callback error:error];
     }];
 }
 
@@ -1000,15 +1033,17 @@ static BOOL enableAutomatic = NO;
             @finally {
                 [AVUtils callIdResultBlock:callback object:dict error:error];
             }
-            
         } else {
             [AVUtils callIdResultBlock:callback object:object error:error];
         }
-        
     }];
 }
 
-
-
 @end
 
+
+@implementation AVUserShortMessageRequestOptions
+
+@dynamic validationToken;
+
+@end

--- a/AVOS/AVOSCloud/Utils/AVDynamicObject.h
+++ b/AVOS/AVOSCloud/Utils/AVDynamicObject.h
@@ -1,0 +1,13 @@
+//
+//  AVDynamicObject.h
+//  AVOS
+//
+//  Created by Tang Tianyong on 27/04/2017.
+//  Copyright © 2017 LeanCloud Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface AVDynamicObject : NSObject
+
+@end

--- a/AVOS/AVOSCloud/Utils/AVDynamicObject.h
+++ b/AVOS/AVOSCloud/Utils/AVDynamicObject.h
@@ -8,6 +8,14 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface AVDynamicObject : NSObject
 
+- (nullable id)objectForKeyedSubscript:(NSString *)key;
+
+- (void)setObject:(nullable id)object forKeyedSubscript:(NSString *)key;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AVOS/AVOSCloud/Utils/AVDynamicObject.m
+++ b/AVOS/AVOSCloud/Utils/AVDynamicObject.m
@@ -9,132 +9,267 @@
 #import "AVDynamicObject.h"
 #import <objc/runtime.h>
 
-static NSString *getterNameFromSetter(SEL selector);
-static NSString *setterNameFromGetterName(NSString *getterName);
+@interface AVDynamicObject ()
 
-static id getter(id self, SEL _cmd) {
-    return [self objectForKey:NSStringFromSelector(_cmd)];
+- (id)objectForSelector:(SEL)selector;
+
+- (void)setObject:(id)object forSelector:(SEL)selector;
+
+@end
+
+
+static char getter_char(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] charValue];
 }
 
-static void setter(id self, SEL _cmd, id value) {
-    [self setObject:value forKey:getterNameFromSetter(_cmd)];
+static void setter_char(id self, SEL _cmd, char value) {
+    [self setObject:@(value) forSelector:_cmd];
 }
 
-static void setterWithCopy(id self, SEL _cmd, id value) {
-    [self setObject:[value copy] forKey:getterNameFromSetter(_cmd)];
+static int getter_int(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] intValue];
 }
 
-static BOOL getter_b(id self, SEL _cmd) {
-    return [[self objectForKey:NSStringFromSelector(_cmd)] boolValue];
+static void setter_int(id self, SEL _cmd, int value) {
+    [self setObject:@(value) forSelector:_cmd];
 }
 
-static void setter_b(id self, SEL _cmd, BOOL value) {
-    [self setObject:@(value) forKey:getterNameFromSetter(_cmd)];
+static short getter_short(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] shortValue];
 }
 
-static long getter_l(id self, SEL _cmd) {
-    return [[self objectForKey:NSStringFromSelector(_cmd)] longValue];
+static void setter_short(id self, SEL _cmd, short value) {
+    [self setObject:@(value) forSelector:_cmd];
 }
 
-static void setter_l(id self, SEL _cmd, long value) {
-    [self setObject:@(value) forKey:getterNameFromSetter(_cmd)];
+static long getter_long(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] longValue];
 }
 
-static long long getter_ll(id self, SEL _cmd) {
-    return [[self objectForKey:NSStringFromSelector(_cmd)] longLongValue];
+static void setter_long(id self, SEL _cmd, long value) {
+    [self setObject:@(value) forSelector:_cmd];
 }
 
-static void setter_ll(id self, SEL _cmd, long long value) {
-    [self setObject:@(value) forKey:getterNameFromSetter(_cmd)];
+static long long getter_long_long(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] longLongValue];
 }
 
-static unsigned long long getter_ull(id self, SEL _cmd) {
-    return [[self objectForKey:NSStringFromSelector(_cmd)] unsignedLongLongValue];
+static void setter_long_long(id self, SEL _cmd, long long value) {
+    [self setObject:@(value) forSelector:_cmd];
 }
 
-static void setter_ull(id self, SEL _cmd, unsigned long long value) {
-    [self setObject:@(value) forKey:getterNameFromSetter(_cmd)];
+static unsigned char getter_unsigned_char(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] unsignedCharValue];
 }
 
-static double getter_d(id self, SEL _cmd) {
-    return [[self objectForKey:NSStringFromSelector(_cmd)] doubleValue];
+static void setter_unsigned_char(id self, SEL _cmd, unsigned char value) {
+    [self setObject:@(value) forSelector:_cmd];
 }
 
-static void setter_d(id self, SEL _cmd, double value) {
-    [self setObject:[NSNumber numberWithDouble:value] forKey:getterNameFromSetter(_cmd)];
+static unsigned int getter_unsigned_int(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] unsignedIntValue];
 }
 
-static float getter_f(id self, SEL _cmd) {
-    return [[self objectForKey:NSStringFromSelector(_cmd)] floatValue];
+static void setter_unsigned_int(id self, SEL _cmd, unsigned int value) {
+    [self setObject:@(value) forSelector:_cmd];
 }
 
-static void setter_f(id self, SEL _cmd, float value) {
-    [self setObject:[NSNumber numberWithFloat:value] forKey:getterNameFromSetter(_cmd)];
+static unsigned short getter_unsigned_short(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] unsignedShortValue];
 }
 
-static
-NSString *getterNameFromSetter(SEL selector) {
-    NSString *string = NSStringFromSelector(selector);
-    NSString *key = [string substringWithRange:NSMakeRange(3, string.length - 4)];
-
-    NSString *firstLetter = [[key substringToIndex:1] lowercaseString];
-    key = [firstLetter stringByAppendingString:[key substringFromIndex:1]];
-
-    return key;
+static void setter_unsigned_short(id self, SEL _cmd, unsigned short value) {
+    [self setObject:@(value) forSelector:_cmd];
 }
 
-static
-NSString *setterNameFromGetterName(NSString *getterName) {
-    NSString *setterName = [NSString stringWithFormat:@"set%@%@:",
-                            [[getterName substringToIndex:1] uppercaseString],
-                            [getterName substringFromIndex:1]];
-    return setterName;
+static unsigned long getter_unsigned_long(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] unsignedLongValue];
+}
+
+static void setter_unsigned_long(id self, SEL _cmd, unsigned long value) {
+    [self setObject:@(value) forSelector:_cmd];
+}
+
+static unsigned long long getter_unsigned_long_long(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] unsignedLongLongValue];
+}
+
+static void setter_unsigned_long_long(id self, SEL _cmd, unsigned long long value) {
+    [self setObject:@(value) forSelector:_cmd];
+}
+
+static float getter_float(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] floatValue];
+}
+
+static void setter_float(id self, SEL _cmd, float value) {
+    [self setObject:@(value) forSelector:_cmd];
+}
+
+static double getter_double(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] doubleValue];
+}
+
+static void setter_double(id self, SEL _cmd, double value) {
+    [self setObject:@(value) forSelector:_cmd];
+}
+
+static BOOL getter_bool(id self, SEL _cmd) {
+    return [[self objectForSelector:_cmd] boolValue];
+}
+
+static void setter_bool(id self, SEL _cmd, BOOL value) {
+    [self setObject:@(value) forSelector:_cmd];
+}
+
+static char *getter_char_pointer(id self, SEL _cmd) {
+    return (char *)[[self objectForSelector:_cmd] unsignedLongLongValue];
+}
+
+static void setter_char_pointer(id self, SEL _cmd, char *value) {
+    [self setObject:@((unsigned long long)value) forSelector:_cmd];
+}
+static id getter_object(id self, SEL _cmd) {
+    return [self objectForSelector:_cmd];
+}
+
+static void setter_object(id self, SEL _cmd, id value) {
+    [self setObject:value forSelector:_cmd];
+}
+
+static void setter_object_copy(id self, SEL _cmd, id value) {
+    [self setObject:[value copy] forSelector:_cmd];
+}
+
+static Class getter_class(id self, SEL _cmd) {
+    return [self objectForSelector:_cmd];
+}
+
+static void setter_class(id self, SEL _cmd, Class value) {
+    [self setObject:value forSelector:_cmd];
+}
+
+static SEL getter_selector(id self, SEL _cmd) {
+    NSString *string = [self objectForSelector:_cmd];
+
+    if (string)
+        return NSSelectorFromString(string);
+    else
+        return NULL;
+}
+
+static void setter_selector(id self, SEL _cmd, SEL value) {
+    if (value)
+        [self setObject:NSStringFromSelector(value) forSelector:_cmd];
+    else
+        [self setObject:nil forSelector:_cmd];
+}
+
+
+NS_INLINE
+BOOL hasProperty(id object, NSString *name) {
+    return class_getProperty(object_getClass(object), name.UTF8String);
+}
+
+NS_INLINE
+NSString *firstLowercaseString(NSString *string) {
+    NSString *firstLetter = [[string substringToIndex:1] lowercaseString];
+    string = [firstLetter stringByAppendingString:[string substringFromIndex:1]];
+
+    return string;
+}
+
+NS_INLINE
+NSString *firstUppercaseString(NSString *string) {
+    NSString *firstLetter = [[string substringToIndex:1] uppercaseString];
+    string = [firstLetter stringByAppendingString:[string substringFromIndex:1]];
+
+    return string;
 }
 
 NS_INLINE
 void synthesizeDynamicProperty(Class aClass, NSString *getterName, const char *type, BOOL isCopy) {
-    NSString *setterName = [NSString stringWithFormat:@"set%@%@:",
-                            [[getterName substringToIndex:1] uppercaseString],
-                            [getterName substringFromIndex:1]];
+    if (!getterName.length)
+        return;
+
+    NSString *setterName = [NSString stringWithFormat:@"set%@:", firstUppercaseString(getterName)];
+
+    SEL getter = NSSelectorFromString(getterName);
+    SEL setter = NSSelectorFromString(setterName);
 
     switch (type[0]) {
-    case '@':
-        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter, "@@:");
-        if (isCopy) {
-            class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setterWithCopy, "v@:@");
-        } else {
-            class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter, "v@:@");
-        }
+    case 'c':
+        class_addMethod(aClass, getter, (IMP)getter_char, "c@:");
+        class_addMethod(aClass, setter, (IMP)setter_char, "v@:c");
         break;
-    case 'f':
-        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_f, "f@:");
-        class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_f, "v@:f");
+    case 'i':
+        class_addMethod(aClass, getter, (IMP)getter_int, "i@:");
+        class_addMethod(aClass, setter, (IMP)setter_int, "v@:i");
         break;
-    case 'd':
-        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_d, "d@:");
-        class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_d, "v@:d");
+    case 's':
+        class_addMethod(aClass, getter, (IMP)getter_short, "s@:");
+        class_addMethod(aClass, setter, (IMP)setter_short, "v@:s");
+        break;
+    case 'l':
+        class_addMethod(aClass, getter, (IMP)getter_long, "l@:");
+        class_addMethod(aClass, setter, (IMP)setter_long, "v@:l");
         break;
     case 'q':
-        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_ll, "q@:");
-        class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_ll, "v@:q");
+        class_addMethod(aClass, getter, (IMP)getter_long_long, "q@:");
+        class_addMethod(aClass, setter, (IMP)setter_long_long, "v@:q");
+        break;
+    case 'C':
+        class_addMethod(aClass, getter, (IMP)getter_unsigned_char, "C@:");
+        class_addMethod(aClass, setter, (IMP)setter_unsigned_char, "v@:C");
+        break;
+    case 'I':
+        class_addMethod(aClass, getter, (IMP)getter_unsigned_int, "I@:");
+        class_addMethod(aClass, setter, (IMP)setter_unsigned_int, "v@:I");
+        break;
+    case 'S':
+        class_addMethod(aClass, getter, (IMP)getter_unsigned_short, "S@:");
+        class_addMethod(aClass, setter, (IMP)setter_unsigned_short, "v@:S");
+        break;
+    case 'L':
+        class_addMethod(aClass, getter, (IMP)getter_unsigned_long, "L@:");
+        class_addMethod(aClass, setter, (IMP)setter_unsigned_long, "v@:L");
         break;
     case 'Q':
-        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_ull, "Q@:");
-        class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_ull, "v@:Q");
+        class_addMethod(aClass, getter, (IMP)getter_unsigned_long_long, "Q@:");
+        class_addMethod(aClass, setter, (IMP)setter_unsigned_long_long, "v@:Q");
+        break;
+    case 'f':
+        class_addMethod(aClass, getter, (IMP)getter_float, "f@:");
+        class_addMethod(aClass, setter, (IMP)setter_float, "v@:f");
+        break;
+    case 'd':
+        class_addMethod(aClass, getter, (IMP)getter_double, "d@:");
+        class_addMethod(aClass, setter, (IMP)setter_double, "v@:d");
         break;
     case 'B':
-        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_b, "B@:");
-        class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_b, "v@:B");
+        class_addMethod(aClass, getter, (IMP)getter_bool, "B@:");
+        class_addMethod(aClass, setter, (IMP)setter_bool, "v@:B");
         break;
-    case 'c':
-        if (@encode(BOOL)[0] == 'c') {
-            class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_b, "B@:");
-            class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_b, "v@:B");
-            break;
-        }
-    default:
-        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_l, "l@:");
-        class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_l, "v@:l");
+    case '*':
+        class_addMethod(aClass, getter, (IMP)getter_char_pointer, "*@:");
+        class_addMethod(aClass, setter, (IMP)setter_char_pointer, "v@:*");
+        break;
+    case '@':
+        class_addMethod(aClass, getter, (IMP)getter_object, "@@:");
+
+        if (isCopy)
+            class_addMethod(aClass, setter, (IMP)setter_object_copy, "v@:@");
+        else
+            class_addMethod(aClass, setter, (IMP)setter_object, "v@:@");
+
+        break;
+    case '#':
+        class_addMethod(aClass, getter, (IMP)getter_class, "#@:");
+        class_addMethod(aClass, setter, (IMP)setter_class, "v@:#");
+        break;
+    case ':':
+        class_addMethod(aClass, getter, (IMP)getter_selector, ":@:");
+        class_addMethod(aClass, setter, (IMP)setter_selector, "v@::");
         break;
     }
 }
@@ -159,6 +294,10 @@ void synthesizeDynamicProperties(Class aClass) {
             free(dynamic);
 
             const char* name = property_getName(property);
+
+            if (!name)
+                continue;
+
             char *type = property_copyAttributeValue(property, "T");
             char *copy = property_copyAttributeValue(property, "C");
 
@@ -176,7 +315,7 @@ void synthesizeDynamicProperties(Class aClass) {
 }
 
 NS_INLINE
-NSMutableDictionary *synthesizedClassTable() {
+NSMutableDictionary *preparedClassTable() {
     static NSMutableDictionary *dictionary = nil;
 
     if (!dictionary)
@@ -186,23 +325,27 @@ NSMutableDictionary *synthesizedClassTable() {
 }
 
 NS_INLINE
-void prepareDynamicPropertiesForEachClass(Class aClass) {
-    NSMutableDictionary *classTable = synthesizedClassTable();
-    NSString *address = [NSString stringWithFormat:@"%p", aClass];
+void prepareEachDynamicClass(Class aClass) {
+    if (!aClass)
+        return;
 
-    if (!classTable[address]) {
-        classTable[address] = @(1);
-        synthesizeDynamicProperties(aClass);
-    }
+    NSMutableDictionary *classTable = preparedClassTable();
+    NSString *key = [NSString stringWithFormat:@"%p", aClass];
+
+    if (classTable[key])
+        return;
+
+    classTable[key] = @(1);
+    synthesizeDynamicProperties(aClass);
 }
 
 NS_INLINE
-void prepareDynamicProperties(Class aClass) {
+void prepareDynamicClass(Class aClass) {
     Class eachClass = aClass;
     Class rootClass = [AVDynamicObject class];
 
     do {
-        prepareDynamicPropertiesForEachClass(eachClass);
+        prepareEachDynamicClass(eachClass);
         if (eachClass == rootClass)
             break;
     } while((eachClass = class_getSuperclass(eachClass)));
@@ -211,10 +354,10 @@ void prepareDynamicProperties(Class aClass) {
 @implementation AVDynamicObject
 
 + (void)initialize {
-    id lockObject = [AVDynamicObject class];
+    id lockAround = [AVDynamicObject class];
 
-    @synchronized (lockObject) {
-        prepareDynamicProperties(self);
+    @synchronized (lockAround) {
+        prepareDynamicClass(self);
     }
 }
 
@@ -240,6 +383,29 @@ void prepareDynamicProperties(Class aClass) {
 
 - (id)objectForKeyedSubscript:(NSString *)key {
     return [self objectForKey:key];
+}
+
+- (void)setObject:(id)object forSelector:(SEL)selector {
+    NSString *name = NSStringFromSelector(selector);
+    name = [name substringWithRange:NSMakeRange(3, name.length - 4)];
+
+    if (hasProperty(self, name)) {
+        [self setObject:object forKey:name];
+    } else {
+        name = firstLowercaseString(name);
+        [self setObject:object forKey:name];
+    }
+}
+
+- (id)objectForSelector:(SEL)selector {
+    NSString *name = NSStringFromSelector(selector);
+
+    if (hasProperty(self, name)) {
+        return [self objectForKey:name];
+    } else {
+        name = firstLowercaseString(name);
+        return [self objectForKey:name];
+    }
 }
 
 - (void)setObject:(id)object forKey:(NSString *)key {

--- a/AVOS/AVOSCloud/Utils/AVDynamicObject.m
+++ b/AVOS/AVOSCloud/Utils/AVDynamicObject.m
@@ -1,0 +1,13 @@
+//
+//  AVDynamicObject.m
+//  AVOS
+//
+//  Created by Tang Tianyong on 27/04/2017.
+//  Copyright © 2017 LeanCloud Inc. All rights reserved.
+//
+
+#import "AVDynamicObject.h"
+
+@implementation AVDynamicObject
+
+@end

--- a/AVOS/AVOSCloud/Utils/AVDynamicObject.m
+++ b/AVOS/AVOSCloud/Utils/AVDynamicObject.m
@@ -234,6 +234,14 @@ void prepareDynamicProperties(Class aClass) {
     }
 }
 
+- (void)setObject:(id)object forKeyedSubscript:(NSString *)key {
+    [self setObject:object forKey:key];
+}
+
+- (id)objectForKeyedSubscript:(NSString *)key {
+    return [self objectForKey:key];
+}
+
 - (void)setObject:(id)object forKey:(NSString *)key {
     [self propertyTable][key] = object;
 }

--- a/AVOS/AVOSCloud/Utils/AVDynamicObject.m
+++ b/AVOS/AVOSCloud/Utils/AVDynamicObject.m
@@ -7,7 +7,239 @@
 //
 
 #import "AVDynamicObject.h"
+#import <objc/runtime.h>
+
+static NSString *getterNameFromSetter(SEL selector);
+static NSString *setterNameFromGetterName(NSString *getterName);
+
+static id getter(id self, SEL _cmd) {
+    return [self objectForKey:NSStringFromSelector(_cmd)];
+}
+
+static void setter(id self, SEL _cmd, id value) {
+    [self setObject:value forKey:getterNameFromSetter(_cmd)];
+}
+
+static void setterWithCopy(id self, SEL _cmd, id value) {
+    [self setObject:[value copy] forKey:getterNameFromSetter(_cmd)];
+}
+
+static BOOL getter_b(id self, SEL _cmd) {
+    return [[self objectForKey:NSStringFromSelector(_cmd)] boolValue];
+}
+
+static void setter_b(id self, SEL _cmd, BOOL value) {
+    [self setObject:@(value) forKey:getterNameFromSetter(_cmd)];
+}
+
+static long getter_l(id self, SEL _cmd) {
+    return [[self objectForKey:NSStringFromSelector(_cmd)] longValue];
+}
+
+static void setter_l(id self, SEL _cmd, long value) {
+    [self setObject:@(value) forKey:getterNameFromSetter(_cmd)];
+}
+
+static long long getter_ll(id self, SEL _cmd) {
+    return [[self objectForKey:NSStringFromSelector(_cmd)] longLongValue];
+}
+
+static void setter_ll(id self, SEL _cmd, long long value) {
+    [self setObject:@(value) forKey:getterNameFromSetter(_cmd)];
+}
+
+static unsigned long long getter_ull(id self, SEL _cmd) {
+    return [[self objectForKey:NSStringFromSelector(_cmd)] unsignedLongLongValue];
+}
+
+static void setter_ull(id self, SEL _cmd, unsigned long long value) {
+    [self setObject:@(value) forKey:getterNameFromSetter(_cmd)];
+}
+
+static double getter_d(id self, SEL _cmd) {
+    return [[self objectForKey:NSStringFromSelector(_cmd)] doubleValue];
+}
+
+static void setter_d(id self, SEL _cmd, double value) {
+    [self setObject:[NSNumber numberWithDouble:value] forKey:getterNameFromSetter(_cmd)];
+}
+
+static float getter_f(id self, SEL _cmd) {
+    return [[self objectForKey:NSStringFromSelector(_cmd)] floatValue];
+}
+
+static void setter_f(id self, SEL _cmd, float value) {
+    [self setObject:[NSNumber numberWithFloat:value] forKey:getterNameFromSetter(_cmd)];
+}
+
+static
+NSString *getterNameFromSetter(SEL selector) {
+    NSString *string = NSStringFromSelector(selector);
+    NSString *key = [string substringWithRange:NSMakeRange(3, string.length - 4)];
+
+    NSString *firstLetter = [[key substringToIndex:1] lowercaseString];
+    key = [firstLetter stringByAppendingString:[key substringFromIndex:1]];
+
+    return key;
+}
+
+static
+NSString *setterNameFromGetterName(NSString *getterName) {
+    NSString *setterName = [NSString stringWithFormat:@"set%@%@:",
+                            [[getterName substringToIndex:1] uppercaseString],
+                            [getterName substringFromIndex:1]];
+    return setterName;
+}
+
+NS_INLINE
+void synthesizeDynamicProperty(Class aClass, NSString *getterName, const char *type, BOOL isCopy) {
+    NSString *setterName = [NSString stringWithFormat:@"set%@%@:",
+                            [[getterName substringToIndex:1] uppercaseString],
+                            [getterName substringFromIndex:1]];
+
+    switch (type[0]) {
+    case '@':
+        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter, "@@:");
+        if (isCopy) {
+            class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setterWithCopy, "v@:@");
+        } else {
+            class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter, "v@:@");
+        }
+        break;
+    case 'f':
+        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_f, "f@:");
+        class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_f, "v@:f");
+        break;
+    case 'd':
+        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_d, "d@:");
+        class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_d, "v@:d");
+        break;
+    case 'q':
+        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_ll, "q@:");
+        class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_ll, "v@:q");
+        break;
+    case 'Q':
+        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_ull, "Q@:");
+        class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_ull, "v@:Q");
+        break;
+    case 'B':
+        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_b, "B@:");
+        class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_b, "v@:B");
+        break;
+    case 'c':
+        if (@encode(BOOL)[0] == 'c') {
+            class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_b, "B@:");
+            class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_b, "v@:B");
+            break;
+        }
+    default:
+        class_addMethod(aClass, NSSelectorFromString(getterName), (IMP)getter_l, "l@:");
+        class_addMethod(aClass, NSSelectorFromString(setterName), (IMP)setter_l, "v@:l");
+        break;
+    }
+}
+
+NS_INLINE
+void synthesizeDynamicProperties(Class aClass) {
+    unsigned int propertyCount = 0;
+    objc_property_t *properties = class_copyPropertyList(aClass, &propertyCount);
+
+    if (!propertyCount) {
+        if (properties)
+            free(properties);
+
+        return;
+    }
+
+    for (unsigned int i = 0; i < propertyCount; ++i) {
+        objc_property_t property = properties[i];
+        char *dynamic = property_copyAttributeValue(property, "D");
+
+        if (dynamic) {
+            free(dynamic);
+
+            const char* name = property_getName(property);
+            char *type = property_copyAttributeValue(property, "T");
+            char *copy = property_copyAttributeValue(property, "C");
+
+            synthesizeDynamicProperty(aClass, @(name), type, copy != NULL);
+
+            if (type)
+                free(type);
+            if (copy)
+                free(copy);
+        }
+    }
+
+    if (properties)
+        free(properties);
+}
+
+NS_INLINE
+NSMutableDictionary *synthesizedClassTable() {
+    static NSMutableDictionary *dictionary = nil;
+
+    if (!dictionary)
+        dictionary = [NSMutableDictionary dictionary];
+
+    return dictionary;
+}
+
+NS_INLINE
+void prepareDynamicPropertiesForEachClass(Class aClass) {
+    NSMutableDictionary *classTable = synthesizedClassTable();
+    NSString *address = [NSString stringWithFormat:@"%p", aClass];
+
+    if (!classTable[address]) {
+        classTable[address] = @(1);
+        synthesizeDynamicProperties(aClass);
+    }
+}
+
+NS_INLINE
+void prepareDynamicProperties(Class aClass) {
+    Class eachClass = aClass;
+    Class rootClass = [AVDynamicObject class];
+
+    do {
+        prepareDynamicPropertiesForEachClass(eachClass);
+        if (eachClass == rootClass)
+            break;
+    } while((eachClass = class_getSuperclass(eachClass)));
+}
 
 @implementation AVDynamicObject
+
++ (void)initialize {
+    id lockObject = [AVDynamicObject class];
+
+    @synchronized (lockObject) {
+        prepareDynamicProperties(self);
+    }
+}
+
+- (NSMutableDictionary *)propertyTable {
+    @synchronized (self) {
+        const char *key = "property-table";
+        NSMutableDictionary *propertyTable = nil;
+        propertyTable = objc_getAssociatedObject(self, key);
+
+        if (propertyTable)
+            return propertyTable;
+
+        propertyTable = [NSMutableDictionary dictionary];
+        objc_setAssociatedObject(self, key, propertyTable, OBJC_ASSOCIATION_RETAIN);
+
+        return propertyTable;
+    }
+}
+
+- (void)setObject:(id)object forKey:(NSString *)key {
+    [self propertyTable][key] = object;
+}
+
+- (id)objectForKey:(NSString *)key {
+    return [self propertyTable][key];
+}
 
 @end

--- a/AVOS/AVOSCloud/Utils/AVDynamicObject_Internal.h
+++ b/AVOS/AVOSCloud/Utils/AVDynamicObject_Internal.h
@@ -10,8 +10,6 @@
 
 @interface AVDynamicObject ()
 
-@property (nonatomic, strong, readonly) NSDictionary *properties;
-
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary;
 
 @end

--- a/AVOS/AVOSCloud/Utils/AVDynamicObject_Internal.h
+++ b/AVOS/AVOSCloud/Utils/AVDynamicObject_Internal.h
@@ -1,0 +1,17 @@
+//
+//  AVDynamicObject_Internal.h
+//  AVOS
+//
+//  Created by Tang Tianyong on 03/05/2017.
+//  Copyright © 2017 LeanCloud Inc. All rights reserved.
+//
+
+#import "AVDynamicObject.h"
+
+@interface AVDynamicObject ()
+
+@property (nonatomic, strong, readonly) NSDictionary *properties;
+
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary;
+
+@end

--- a/AVOS/AVOSCloud/Utils/NSDictionary+LeanCloud.h
+++ b/AVOS/AVOSCloud/Utils/NSDictionary+LeanCloud.h
@@ -1,0 +1,15 @@
+//
+//  NSDictionary+LeanCloud.h
+//  AVOS
+//
+//  Created by Tang Tianyong on 03/05/2017.
+//  Copyright © 2017 LeanCloud Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSDictionary (LeanCloud)
+
+- (instancetype)lc_selectEntriesWithKeyMappings:(NSDictionary *)keyMappings;
+
+@end

--- a/AVOS/AVOSCloud/Utils/NSDictionary+LeanCloud.m
+++ b/AVOS/AVOSCloud/Utils/NSDictionary+LeanCloud.m
@@ -1,0 +1,22 @@
+//
+//  NSDictionary+LeanCloud.m
+//  AVOS
+//
+//  Created by Tang Tianyong on 03/05/2017.
+//  Copyright © 2017 LeanCloud Inc. All rights reserved.
+//
+
+#import "NSDictionary+LeanCloud.h"
+
+@implementation NSDictionary (LeanCloud)
+
+- (instancetype)lc_selectEntriesWithKeyMappings:(NSDictionary *)keyMappings {
+    NSMutableDictionary *selected = [NSMutableDictionary dictionary];
+
+    for (id sourceKey in keyMappings)
+        selected[keyMappings[sourceKey]] = self[sourceKey];
+
+    return selected;
+}
+
+@end


### PR DESCRIPTION
支持短信图形验证码和短信签名，并作废了原有的短信接口。

引入了一个新的类型来包装请求选项，确定了未来 Objective-C SDK 在处理多选项时的接口形式。

API 的变动如下：

作废了 `AVOSCloud` 类中原来的短信请求接口。引入新类 `AVSMS`，逐步将非用户相关的短信相关接口放在 `AVSMS` 中，为未来的模块拆分做好准备。作废的 4 个接口合成为 1 个新的接口：

```objc
@interface AVSMS : NSObject

+ (void)requestShortMessageForPhoneNumber:(NSString *)phoneNumber
                                  options:(nullable AVShortMessageRequestOptions *)options
                                 callback:(AVBooleanResultBlock)callback;

@end
```

`AVUser` 中的 3 个短信请求接口分别增加了 options 参数，接口如下：

```objc
@interface AVUser : AVObject

+ (void)requestVerificationCodeForPhoneNumber:(NSString *)phoneNumber
                                      options:(nullable AVUserShortMessageRequestOptions *)options
                                     callback:(AVBooleanResultBlock)callback;

+ (void)requestLoginCodeForPhoneNumber:(NSString *)phoneNumber
                               options:(nullable AVUserShortMessageRequestOptions *)options
                              callback:(AVBooleanResultBlock)callback;

+ (void)requestPasswordResetCodeForPhoneNumber:(NSString *)phoneNumber
                                       options:(nullable AVUserShortMessageRequestOptions *)options
                                      callback:(AVBooleanResultBlock)callback;

@end
```

最后，图像验证码单独放在一个类 `AVCaptcha` 中：

```objc
@interface AVCaptcha : NSObject

+ (void)requestCaptchaWithOptions:(nullable AVCaptchaRequestOptions *)options
                         callback:(AVCaptchaRequestCallback)callback;

+ (void)verifyCaptchaCode:(NSString *)captchaCode
          forCaptchaToken:(NSString *)captchaToken
                 callback:(AVCaptchaVerificationCallback)callback;

@end
```

@leancloud/sdk-only 