### PR TITLE
Avoid to crash if SDK not initialized correctly

### DIFF
--- a/AVOS/AVOSCloud/Router/LCRouter.m
+++ b/AVOS/AVOSCloud/Router/LCRouter.m
@@ -202,7 +202,14 @@ typedef NS_ENUM(NSInteger, LCServerLocation) {
     if (LCEffectiveServiceRegion == AVServiceRegionUS)
         return;
 
-    NSDictionary *parameters = @{@"appId": [AVOSCloud getApplicationId]};
+    NSString *applicationId = [AVOSCloud getApplicationId];
+
+    if (!applicationId) {
+        AVLoggerError(AVLoggerDomainStorage, @"LeanCloud SDK not initialized.");
+        return;
+    }
+
+    NSDictionary *parameters = @{@"appId": applicationId};
 
     [[AVPaasClient sharedInstance] getObject:routerURLString withParameters:parameters block:^(NSDictionary *result, NSError *error) {
         if (!error && result)


### PR DESCRIPTION
防止 SDK 在用户未正确初始化的情况下崩溃，关联 #234 。

@leancloud/ios-group 