### PR TITLE
Remove dependency quartz for watchos platform

### DIFF
--- a/Podspec/AVOSCloud.podspec.mustache
+++ b/Podspec/AVOSCloud.podspec.mustache
@@ -79,7 +79,6 @@ Pod::Spec.new do |s|
     'CoreGraphics',
     'CoreLocation',
     'MobileCoreServices',
-    'QuartzCore',
     'Security'
 
   s.libraries =


### PR DESCRIPTION
Watchos 没有这个 QuartzCore 这个 framework，在新版 Xcode 中会编译失败。