### PR TITLE
Avoid to block main thread when sending file message

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMConversation.m
+++ b/AVOS/AVOSCloudIM/AVIMConversation.m
@@ -670,9 +670,11 @@ static dispatch_queue_t messageCacheOperationQueue;
                 [file saveInBackgroundWithBlock:^(BOOL succeeded, NSError *error) {
                     if (succeeded) {
                         /* If uploading is success, bind file to message */
-                        [self fillTypedMessage:typedMessage withFile:file];
-                        [self fillTypedMessageForLocationIfNeeded:typedMessage];
-                        [self sendRealMessage:message option:option callback:callback];
+                        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                            [self fillTypedMessage:typedMessage withFile:file];
+                            [self fillTypedMessageForLocationIfNeeded:typedMessage];
+                            [self sendRealMessage:message option:option callback:callback];
+                        });
                     } else {
                         message.status = AVIMMessageStatusFailed;
                         [AVIMBlockHelper callBooleanResultBlock:callback error:error];


### PR DESCRIPTION
修复当发送通过外部 URL 创建的图片类型消息时，当前线程被 block 的问题。关联 #200 。

@leancloud/ios-group 