### PR TITLE
Fix crash for IM SSL pinning

### DIFF
--- a/AVOS/AVOSCloud/Router/LCRouter.m
+++ b/AVOS/AVOSCloud/Router/LCRouter.m
@@ -363,12 +363,6 @@ found:
     parameters[@"appId"] = appId;
     parameters[@"secure"] = @"1";
 
-    /*
-     * iOS SDK *must* use IP address to access IM server to prevent DNS hijacking.
-     * And IM server *must* issue the pinned certificate.
-     */
-    parameters[@"ip"] = @"true";
-
     /* Back door for user to connect to puppet environment. */
     if (getenv("LC_IM_PUPPET_ENABLED") && getenv("SIMULATOR_UDID")) {
         parameters[@"debug"] = @"true";

--- a/AVOS/AVOSCloudIM/Vendor/SocketRocket/AVIMWebSocket.m
+++ b/AVOS/AVOSCloudIM/Vendor/SocketRocket/AVIMWebSocket.m
@@ -1437,7 +1437,8 @@ SecKeyRef LCGetPublicKeyFromCertificate(SecCertificateRef cert);
  * @param certs Certificate array, it should be an array of SecCertificateRef.
  * @return An array of public keys.
  */
-- (NSArray *)publicKeysFromCerts:(NSArray *)certs {
+NS_INLINE
+NSArray *LCPublicKeysFromCerts(NSArray *certs) {
     NSMutableArray *publicKeys = [NSMutableArray array];
     
     for (id cert in certs) {
@@ -1459,7 +1460,7 @@ SecKeyRef LCGetPublicKeyFromCertificate(SecCertificateRef cert);
     
     SecPolicyRef policy = SecPolicyCreateBasicX509();
     NSInteger numCerts = SecTrustGetCertificateCount(secTrust);
-    NSArray *pinnedPublicKeys = [self publicKeysFromCerts:sslCerts];
+    NSArray *pinnedPublicKeys = LCPublicKeysFromCerts(sslCerts);
     
     for (NSInteger i = 0; i < numCerts; i++) {
         SecCertificateRef cert = SecTrustGetCertificateAtIndex(secTrust, i);


### PR DESCRIPTION
修复 IM SSL pinning 偶尔 crash 的问题，把从证书中提取 public keys 的逻辑独立出来了。

@leancloud/ios-group 