### PR TITLE
Move media type property to common message

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMMessage.h
+++ b/AVOS/AVOSCloudIM/AVIMMessage.h
@@ -8,6 +8,16 @@
 
 #import "AVIMCommon.h"
 
+typedef NS_ENUM(int8_t, AVIMMessageMediaType) {
+    kAVIMMessageMediaTypeNone = 0,
+    kAVIMMessageMediaTypeText = -1,
+    kAVIMMessageMediaTypeImage = -2,
+    kAVIMMessageMediaTypeAudio = -3,
+    kAVIMMessageMediaTypeVideo = -4,
+    kAVIMMessageMediaTypeLocation = -5,
+    kAVIMMessageMediaTypeFile = -6
+};
+
 typedef NS_ENUM(int8_t, AVIMMessageIOType) {
     AVIMMessageIOTypeIn = 1,
     AVIMMessageIOTypeOut,
@@ -25,6 +35,8 @@ typedef NS_ENUM(int8_t, AVIMMessageStatus) {
 NS_ASSUME_NONNULL_BEGIN
 
 @interface AVIMMessage : NSObject <NSCopying, NSCoding>
+
+@property (nonatomic, assign, readonly) AVIMMessageMediaType mediaType;
 
 /*!
  * 表示接收和发出的消息

--- a/AVOS/AVOSCloudIM/AVIMMessage_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMMessage_Internal.h
@@ -10,6 +10,8 @@
 
 @interface AVIMMessage ()
 
+@property (nonatomic, assign) AVIMMessageMediaType mediaType;
+
 /*!
  * Wether message has breakpoint or not
  */

--- a/AVOS/AVOSCloudIM/TypedMessages/AVIMTypedMessage.h
+++ b/AVOS/AVOSCloudIM/TypedMessages/AVIMTypedMessage.h
@@ -11,19 +11,6 @@
 @class AVFile;
 @class AVGeoPoint;
 
-typedef int8_t AVIMMessageMediaType;
-
-//SDK定义的消息类型，自定义类型使用大于0的值
-enum : AVIMMessageMediaType {
-    kAVIMMessageMediaTypeNone = 0,
-    kAVIMMessageMediaTypeText = -1,
-    kAVIMMessageMediaTypeImage = -2,
-    kAVIMMessageMediaTypeAudio = -3,
-    kAVIMMessageMediaTypeVideo = -4,
-    kAVIMMessageMediaTypeLocation = -5,
-    kAVIMMessageMediaTypeFile = -6
-};
-
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol AVIMTypedMessageSubclassing <NSObject>
@@ -40,7 +27,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface AVIMTypedMessage : AVIMMessage
 
-@property (nonatomic, assign)                     AVIMMessageMediaType  mediaType;  // 消息类型，可自定义
 @property (nonatomic,   copy, nullable)           NSString             *text;       // 消息文本
 @property (nonatomic, strong, nullable)           NSDictionary         *attributes; // 自定义属性
 @property (nonatomic, strong, readonly, nullable) AVFile               *file;       // 附件


### PR DESCRIPTION
将 mediaType 移到 AVIMMessage 中，并将其设置为 readonly。用户判断消息类型时，就不用先判断 class 了，直接用 switch 语句判断 mediaType 即可：

```objc
switch (message.mediaType) {
case kAVIMMessageMediaTypeNone:
    /* non-typed message. */
    break;
case kAVIMMessageMediaTypeText:
    /* text message. */
    break;
}
```

@leancloud/ios-group @nicecui 