### PR TITLE
Fix session conflict for first installation

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -436,6 +436,11 @@ static BOOL AVIMClientHasInstantiated = NO;
 
     command.sessionMessage.r = !force;
 
+    NSString *deviceToken = [AVInstallation currentInstallation].deviceToken;
+
+    if (deviceToken)
+        command.sessionMessage.deviceToken = deviceToken;
+
     OSAtomicIncrement32(&_openTimes);
 
     [self sendCommand:command];


### PR DESCRIPTION
修复当应用首次安装，client 成功登录，然后将 app 切换至后台并重新唤醒时，client 重连会触发 SESSION_CONFLICT 的问题。

问题的原因是：真实的 device token 在 client 重连之前已经 report 到了服务端，旧的 UUID 已经失效。如果重连时带上这个旧的 UUID，将会触发 SESSION_CONFLICT。

@leancloud/sdk-only