### PR TITLE
Update last message timestamp when unread did receive

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -969,12 +969,21 @@ static BOOL AVIMClientHasInstantiated = NO;
 
     AVIMMessage *originLastMessage = conversation.lastMessage;
 
-    if (lastMessage && (!originLastMessage || lastMessage.sendTimestamp > originLastMessage.sendTimestamp))
+    if (lastMessage && (!originLastMessage || lastMessage.sendTimestamp > originLastMessage.sendTimestamp)) {
         LCIM_NOTIFY_PROPERTY_UPDATE(
             self.clientId,
             conversation.conversationId,
             NSStringFromSelector(@selector(lastMessage)),
             lastMessage);
+
+        NSDate *lastMessageAt = [NSDate dateWithTimeIntervalSince1970:(lastMessage.sendTimestamp / 1000.0)];
+
+        LCIM_NOTIFY_PROPERTY_UPDATE(
+            self.clientId,
+            self.conversationId,
+            NSStringFromSelector(@selector(lastMessageAt)),
+            lastMessageAt);
+    }
 
     /* For compatibility, we reserve this callback. It should be removed in future. */
     if ([self.delegate respondsToSelector:@selector(conversation:didReceiveUnread:)])


### PR DESCRIPTION
当收到未读消息时，更新对话 lastMessage 的同时也更新 lastMessageAt 属性。关联 issue #286 。

@leancloud/ios-group @nicecui 