### PR TITLE
Tune default WebSocket timeout to 30s

### DIFF
--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -38,7 +38,7 @@
     @"------ END --------------------------------\n" \
     @"\n"
 
-static NSTimeInterval AVIMWebSocketDefaultTimeoutInterval = 15.0;
+static NSTimeInterval AVIMWebSocketDefaultTimeoutInterval = 30.0;
 
 typedef enum : NSUInteger {
     //mutually exclusive


### PR DESCRIPTION
当连接上数据较多时，服务端可能不会将 pong 及时下发下来。
如果 SDK 没有在超时时间内收到 pong，SDK 将会主动断开连接。

因此增加一下超时时间，延长到 30 秒。

@leancloud/ios-group 