### PR TITLE
Add a new API to switch unread notification

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMClient.h
+++ b/AVOS/AVOSCloudIM/AVIMClient.h
@@ -106,7 +106,16 @@ NS_ASSUME_NONNULL_BEGIN
  * 该接口用于控制 AVIMClient 的一些细节行为。
  * @param userOptions 用户选项。
  */
-+ (void)setUserOptions:(NSDictionary *)userOptions;
++ (void)setUserOptions:(NSDictionary *)userOptions AVIM_DEPRECATED("Deprecated in v5.1.0. Do not use it any more.");
+
+/*!
+ Set what server will issues for offline messages when client did login.
+
+ @param enabled Set `YES` if you want server issues concrete offline messages.
+                Set `NO` if you want server just issues the count of offline messages in each conversation.
+                Defaults to `NO`.
+ */
++ (void)setUnreadNotificationEnabled:(BOOL)enabled;
 
 /*!
  * 设置实时通信的超时时间，默认 15 秒。

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -27,6 +27,7 @@
 #import "AVIMCommandCommon.h"
 #import "LCObserver.h"
 #import "SDMacros.h"
+#import "AVIMUserOptions.h"
 
 #import <objc/runtime.h>
 #import <libkern/OSAtomic.h>
@@ -1310,17 +1311,32 @@ static BOOL AVIMClientHasInstantiated = NO;
     }
 }
 
-static NSDictionary *AVIMUserOptions = nil;
++ (NSMutableDictionary *)userOptions {
+    static dispatch_once_t onceToken;
+    static NSMutableDictionary *userOptions;
+
+    dispatch_once(&onceToken, ^{
+        userOptions = [NSMutableDictionary dictionary];
+    });
+
+    return userOptions;
+}
 
 + (void)setUserOptions:(NSDictionary *)userOptions {
     if (AVIMClientHasInstantiated) {
         [NSException raise:NSInternalInconsistencyException format:@"AVIMClient user options should be set before instantiation"];
     }
-    AVIMUserOptions = userOptions;
+
+    if (!userOptions)
+        return;
+
+    [[self userOptions] addEntriesFromDictionary:userOptions];
 }
 
-+ (NSDictionary *)userOptions {
-    return AVIMUserOptions;
++ (void)setUnreadNotificationEnabled:(BOOL)enabled {
+    [self setUserOptions:@{
+        AVIMUserOptionUseUnread: @(enabled)
+    }];
 }
 
 @end

--- a/AVOS/AVOSCloudIM/AVIMClient_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMClient_Internal.h
@@ -11,7 +11,7 @@
 
 @interface AVIMClient ()
 
-+ (NSDictionary *)userOptions;
++ (NSMutableDictionary *)userOptions;
 + (dispatch_queue_t)imClientQueue;
 + (BOOL)checkErrorForSignature:(AVIMSignature *)signature command:(AVIMGenericCommand *)command;
 + (void)_assertClientIdsIsValid:(NSArray *)clientIds;

--- a/AVOS/AVOSCloudIM/AVIMUserOptions.h
+++ b/AVOS/AVOSCloudIM/AVIMUserOptions.h
@@ -7,17 +7,18 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "AVIMAvailability.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /*
  * 开启未读通知，关闭离线消息推送。
  */
-FOUNDATION_EXPORT NSString *const AVIMUserOptionUseUnread;
+FOUNDATION_EXPORT NSString *const AVIMUserOptionUseUnread AVIM_DEPRECATED("Deprecated in v5.1.0. Use `+[AVIMClient setUnreadNotificationEnabled:]` instead.");
 
 /*
  * 自定义消息传输协议。如果没有特殊目的，不应该使用这个选项。
  */
-FOUNDATION_EXPORT NSString *const AVIMUserOptionCustomProtocols;
+FOUNDATION_EXPORT NSString *const AVIMUserOptionCustomProtocols AVIM_DEPRECATED("Deprecated in v5.1.0. Do not use it any more.");
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
添加一个新接口，用来开启或关闭未读消息数通知。关联 https://github.com/leancloud/paas/issues/945 。

@leancloud/ios-group @leancloud/tech-support @leancloud/android-group 