### PR TITLE
Remove unnecessary appid for some IM commands

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -521,7 +521,6 @@ static BOOL AVIMClientHasInstantiated = NO;
     AVIMGenericCommand *genericCommand = [[AVIMGenericCommand alloc] init];
     genericCommand.cmd = AVIMCommandType_Report;
     genericCommand.op = AVIMOpType_Upload;
-    genericCommand.appId = [AVOSCloud getApplicationId];
     genericCommand.peerId = _clientId;
 
     AVIMReportCommand *reportCommand = [[AVIMReportCommand alloc] init];
@@ -1287,7 +1286,6 @@ static BOOL AVIMClientHasInstantiated = NO;
 - (void)sendACKForPatchCommand:(AVIMGenericCommand *)inCommand {
     AVIMGenericCommand *command = [[AVIMGenericCommand alloc] init];
 
-    command.appId  = [AVOSCloud getApplicationId];
     command.peerId = self.clientId;
 
     command.cmd = AVIMCommandType_Patch;


### PR DESCRIPTION
除了IM session open 以及 LiveQuery login 会传 appId，其他命令都不会传了。

@leancloud/ios-group @ylgrgyq 