### PR TITLE
Avoid to update object for nil key

### DIFF
--- a/AVOS/AVOSCloud/Object/AVObject.m
+++ b/AVOS/AVOSCloud/Object/AVObject.m
@@ -320,6 +320,8 @@ BOOL requests_contain_request(NSArray *requests, NSDictionary *request) {
 }
 
 - (void)updateValue:(id)value forKey:(NSString *)key {
+    if (!key)
+        return;
     if ([AVUtils containsProperty:key inClass:[self class] containSuper:YES filterDynamic:YES]) {
         self.inSetter = YES;
         [self setValue:value forKey:key];


### PR DESCRIPTION
避免更新 object 时，因 key 为 nil 导致 crash。这里做一下防御。