### PR TITLE
Ignore response data when cloud request succeeded

### DIFF
--- a/AVOS/AVOSCloud/CloudCode/AVCloud.m
+++ b/AVOS/AVOSCloud/CloudCode/AVCloud.m
@@ -55,14 +55,7 @@
     [[AVPaasClient sharedInstance]
      performRequest:request
      success:^(NSHTTPURLResponse *response, id responseObject) {
-         NSError *serverError = [AVErrorUtils errorFromJSON:responseObject];
-
-         if (serverError) {
-             error = serverError;
-         } else {
-             result = [self processedFunctionResultFromObject:responseObject[@"result"]];
-         }
-
+         result = [self processedFunctionResultFromObject:responseObject[@"result"]];
          finished = YES;
      }
      failure:^(NSHTTPURLResponse *response, id responseObject, NSError *inError) {


### PR DESCRIPTION
修复云函数调用的一个错误，尊重 HTTP 错误码，对成功的响应不做检查。