### PR TITLE
Remove file deletion operation if upload failed

### DIFF
--- a/AVOS/AVOSCloud/File/AVUploaderManager.m
+++ b/AVOS/AVOSCloud/File/AVUploaderManager.m
@@ -205,8 +205,6 @@ static uint64_t const QCloudSliceSize = 512 * 1024;
             }
             
             [AVFile cacheFile:file];
-        } else {
-            [file deleteInBackground];
         }
         [AVUtils callBooleanResultBlock:resultBlock error:error];
     };


### PR DESCRIPTION
修复 #316 中的问题。
去掉 s3 文件上传失败时 SDK 主动对文件的清理，因为已经有 fileCallback 接口做了这件事。

@BinaryHB 