### PR TITLE
Support to login with user

### DIFF
--- a/AVOS/AVOSCloud/Request/AVPaasClient.h
+++ b/AVOS/AVOSCloud/Request/AVPaasClient.h
@@ -129,4 +129,9 @@ FOUNDATION_EXPORT NSString *const LCHeaderFieldNameProduction;
                success:(void (^)(NSHTTPURLResponse *response, id responseObject))successBlock
                failure:(void (^)(NSHTTPURLResponse *response, id responseObject, NSError *error))failureBlock;
 
+- (void)performRequest:(NSURLRequest *)request
+               success:(void (^)(NSHTTPURLResponse *response, id responseObject))successBlock
+               failure:(void (^)(NSHTTPURLResponse *response, id responseObject, NSError *error))failureBlock
+                  wait:(BOOL)wait;
+
 @end

--- a/AVOS/AVOSCloud/ThirdParty/libextobjc/EXTScope.h
+++ b/AVOS/AVOSCloud/ThirdParty/libextobjc/EXTScope.h
@@ -32,61 +32,6 @@
     ext_keywordify \
     __strong ext_cleanupBlock_t metamacro_concat(ext_exitBlock_, __LINE__) __attribute__((cleanup(lc_executeCleanupBlock), unused)) = ^
 
-/**
- * Creates \c __weak shadow variables for each of the variables provided as
- * arguments, which can later be made strong again with #strongify.
- *
- * This is typically used to weakly reference variables in a block, but then
- * ensure that the variables stay alive during the actual execution of the block
- * (if they were live upon entry).
- *
- * See #strongify for an example of usage.
- */
-#define weakify(...) \
-    ext_keywordify \
-    metamacro_foreach_cxt(ext_weakify_,, __weak, __VA_ARGS__)
-
-/**
- * Like #weakify, but uses \c __unsafe_unretained instead, for targets or
- * classes that do not support weak references.
- */
-#define unsafeify(...) \
-    ext_keywordify \
-    metamacro_foreach_cxt(ext_weakify_,, __unsafe_unretained, __VA_ARGS__)
-
-/**
- * Strongly references each of the variables provided as arguments, which must
- * have previously been passed to #weakify.
- *
- * The strong references created will shadow the original variable names, such
- * that the original names can be used without issue (and a significantly
- * reduced risk of retain cycles) in the current scope.
- *
- * @code
-
-    id foo = [[NSObject alloc] init];
-    id bar = [[NSObject alloc] init];
-
-    @weakify(foo, bar);
-
-    // this block will not keep 'foo' or 'bar' alive
-    BOOL (^matchesFooOrBar)(id) = ^ BOOL (id obj){
-        // but now, upon entry, 'foo' and 'bar' will stay alive until the block has
-        // finished executing
-        @strongify(foo, bar);
-
-        return [foo isEqual:obj] || [bar isEqual:obj];
-    };
-
- * @endcode
- */
-#define strongify(...) \
-    ext_keywordify \
-    _Pragma("clang diagnostic push") \
-    _Pragma("clang diagnostic ignored \"-Wshadow\"") \
-    metamacro_foreach(ext_strongify_,, __VA_ARGS__) \
-    _Pragma("clang diagnostic pop")
-
 /*** implementation details follow ***/
 typedef void (^ext_cleanupBlock_t)();
 
@@ -97,12 +42,6 @@ extern "C" {
 #if defined(__cplusplus)
 }
 #endif
-
-#define ext_weakify_(INDEX, CONTEXT, VAR) \
-    CONTEXT __typeof__(VAR) metamacro_concat(VAR, _weak_) = (VAR);
-
-#define ext_strongify_(INDEX, VAR) \
-    __strong __typeof__(VAR) VAR = metamacro_concat(VAR, _weak_);
 
 // Details about the choice of backing keyword:
 //

--- a/AVOS/AVOSCloudIM/AVIMClient.h
+++ b/AVOS/AVOSCloudIM/AVIMClient.h
@@ -124,12 +124,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithUser:(AVUser *)user tag:(nullable NSString *)tag;
 
 /*!
- 默认 AVIMClient 实例
- @return AVIMClient 实例
- */
-+ (instancetype)defaultClient;
-
-/*!
  * 设置用户选项。
  * 该接口用于控制 AVIMClient 的一些细节行为。
  * @param userOptions 用户选项。
@@ -150,12 +144,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @param seconds 超时时间，单位是秒。
  */
 + (void)setTimeoutIntervalInSeconds:(NSTimeInterval)seconds;
-
-/*!
- 重置默认 AVIMClient 实例
- 置后再调用 +defaultClient 将返回新的实例
- */
-+ (void)resetDefaultClient;
 
 /*!
  开启某个账户的聊天

--- a/AVOS/AVOSCloudIM/AVIMClient.h
+++ b/AVOS/AVOSCloudIM/AVIMClient.h
@@ -17,6 +17,7 @@
 @class AVIMTypedMessage;
 @class AVIMConversationQuery;
 @class AVIMClientOpenOption;
+@class AVUser;
 
 @protocol AVIMClientDelegate;
 
@@ -66,6 +67,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly, nullable) NSString *clientId;
 
 /**
+ The user that you login as a client.
+ */
+@property (nonatomic, strong, readonly, nullable) AVUser *user;
+
+/**
  * Tag of current client.
  * @brief If tag is not nil and "default", offline mechanism is enabled.
  * @discussion If one client id login on two different devices, previous opened client will be gone offline by later opened client.
@@ -94,6 +100,21 @@ NS_ASSUME_NONNULL_BEGIN
  @param tag      Tag of client.
  */
 - (instancetype)initWithClientId:(NSString *)clientId tag:(nullable NSString *)tag;
+
+/*!
+ Initializes client with an user and a tag.
+
+ This method allows you to use an user as a client to login to IM.
+ Using user as an IM client has some extra benifits. For example, It will activate
+ login signature to improve security. Besides that, you can also take advantage of
+ the friendship relations of users.
+
+ @note You should enable login signature option in application console before you call this method.
+
+ @param user An user who has logged in.
+ @param tag  Tag of client.
+ */
+- (instancetype)initWithUser:(AVUser *)user tag:(nullable NSString *)tag;
 
 /*!
  默认 AVIMClient 实例

--- a/AVOS/AVOSCloudIM/AVIMClient.h
+++ b/AVOS/AVOSCloudIM/AVIMClient.h
@@ -102,6 +102,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithClientId:(NSString *)clientId tag:(nullable NSString *)tag;
 
 /*!
+ Initializes client with an user.
+
+ @seealso It's a convenience initializer of <code>-[AVIMClient initWithUser:tag:]</code>
+ */
+- (instancetype)initWithUser:(AVUser *)user;
+
+/*!
  Initializes client with an user and a tag.
 
  This method allows you to use an user as a client to login to IM.

--- a/AVOS/AVOSCloudIM/AVIMClient.h
+++ b/AVOS/AVOSCloudIM/AVIMClient.h
@@ -340,13 +340,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface AVIMClient (AVDeprecated)
 
-- (void)openWithClientId:(NSString *)clientId
-                callback:(AVIMBooleanResultBlock)callback AVIM_DEPRECATED("Deprecated in AVOSCloudIM SDK 3.1.7.2. Use -[AVIMClient openWithCallback:] or -[AVIMClient openWithOption:callback:] instead.");
-
-- (void)openWithClientId:(NSString *)clientId
-                     tag:(nullable NSString *)tag
-                callback:(AVIMBooleanResultBlock)callback AVIM_DEPRECATED("Deprecated in AVOSCloudIM SDK 3.1.7.2. Use -[AVIMClient openWithCallback:] or -[AVIMClient openWithOption:callback:] instead.");
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -561,10 +561,10 @@ static BOOL AVIMClientHasInstantiated = NO;
     if (option)
         force = option.force;
 
-    [self openWithClientId:self.clientId security:YES tag:self.tag force:force callback:callback];
+    [self openWithClientId:self.clientId tag:self.tag force:force callback:callback];
 }
 
-- (void)openWithClientId:(NSString *)clientId security:(BOOL)security tag:(NSString *)tag force:(BOOL)force callback:(AVIMBooleanResultBlock)callback {
+- (void)openWithClientId:(NSString *)clientId tag:(NSString *)tag force:(BOOL)force callback:(AVIMBooleanResultBlock)callback {
     // Validate client id
     if (!clientId) {
         [NSException raise:NSInternalInconsistencyException format:@"Client id can not be nil."];
@@ -588,7 +588,7 @@ static BOOL AVIMClientHasInstantiated = NO;
         if (self.status != AVIMClientStatusOpened) {
             self.clientId = clientId;
             self.tag = tag;
-            self.socketWrapper = [self socketWrapperForSecurity:security];
+            self.socketWrapper = [self socketWrapperForSecurity:YES];
             self.openTimes = 0;
             self.openCommand = [self openCommandWithAppId:appId
                                                  clientId:clientId
@@ -610,7 +610,7 @@ static BOOL AVIMClientHasInstantiated = NO;
                     [self changeStatus:AVIMClientStatusClosed];
 
                     if ([self shouldRetryForCommand:inCommand]) {
-                        [self openWithClientId:clientId security:security tag:tag force:force callback:callback];
+                        [self openWithClientId:clientId tag:tag force:force callback:callback];
                     } else {
                         [AVIMBlockHelper callBooleanResultBlock:callback error:error];
                     }

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -34,10 +34,8 @@
 #import <libkern/OSAtomic.h>
 
 static const int kMaxClientIdLength = 64;
-static AVIMClient *defaultClient = nil;
 
 static dispatch_queue_t imClientQueue = NULL;
-static dispatch_queue_t defaultClientAccessQueue = NULL;
 
 static const NSUInteger kDistinctMessageIdArraySize = 10;
 
@@ -72,7 +70,6 @@ static BOOL AVIMClientHasInstantiated = NO;
     
     dispatch_once(&onceToken, ^{
         imClientQueue = dispatch_queue_create("cn.leancloud.im", DISPATCH_QUEUE_SERIAL);
-        defaultClientAccessQueue = dispatch_queue_create("cn.leancloud.imclient", DISPATCH_QUEUE_SERIAL);
     });
 }
 
@@ -81,25 +78,8 @@ static BOOL AVIMClientHasInstantiated = NO;
     return [super alloc];
 }
 
-+ (instancetype)defaultClient {
-    __block AVIMClient *client = nil;
-    dispatch_sync(defaultClientAccessQueue, ^{
-        if (!defaultClient) {
-            defaultClient = [[self alloc] init];
-        }
-        client = defaultClient;
-    });
-    return client;
-}
-
 + (void)setTimeoutIntervalInSeconds:(NSTimeInterval)seconds {
     [AVIMWebSocketWrapper setTimeoutIntervalInSeconds:seconds];
-}
-
-+ (void)resetDefaultClient {
-    dispatch_sync(defaultClientAccessQueue, ^{
-        defaultClient = nil;
-    });
 }
 
 + (dispatch_queue_t)imClientQueue {

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -41,6 +41,11 @@ static dispatch_queue_t defaultClientAccessQueue = NULL;
 
 static const NSUInteger kDistinctMessageIdArraySize = 10;
 
+typedef NS_ENUM(NSInteger, LCIMClientLoginMethod) {
+    LCIMClientLoginMethodID = 0,
+    LCIMClientLoginMethodUser
+};
+
 typedef NS_ENUM(NSUInteger, LCIMClientSessionOptions) {
     LCIMClientSessionEnableMessagePatch = 1 << 0
 };
@@ -49,6 +54,12 @@ NS_INLINE
 BOOL isValidTag(NSString *tag) {
     return tag && ![tag isEqualToString:LCIMTagDefault];
 }
+
+@interface AVIMClient ()
+
+@property (nonatomic, assign) LCIMClientLoginMethod loginMethod;
+
+@end
 
 @implementation AVIMClient {
     NSMutableArray *_distinctMessageIdArray;
@@ -142,6 +153,20 @@ static BOOL AVIMClientHasInstantiated = NO;
     if (self) {
         _clientId = [clientId copy];
         _tag = [tag copy];
+
+        [self doInitialization];
+    }
+
+    return self;
+}
+
+- (instancetype)initWithUser:(AVUser *)user tag:(NSString *)tag {
+    self = [super init];
+
+    if (self) {
+        _user = user;
+        _tag = [tag copy];
+        _loginMethod = LCIMClientLoginMethodUser;
 
         [self doInitialization];
     }

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -568,7 +568,7 @@ static BOOL AVIMClientHasInstantiated = NO;
 }
 
 - (void)openWithCallback:(AVIMBooleanResultBlock)callback {
-    [self openWithClientId:self.clientId security:YES tag:self.tag force:NO callback:callback];
+    [self openWithOption:nil callback:callback];
 }
 
 - (void)openWithOption:(AVIMClientOpenOption *)option callback:(AVIMBooleanResultBlock)callback {
@@ -578,14 +578,6 @@ static BOOL AVIMClientHasInstantiated = NO;
         force = option.force;
 
     [self openWithClientId:self.clientId security:YES tag:self.tag force:force callback:callback];
-}
-
-- (void)openWithClientId:(NSString *)clientId callback:(AVIMBooleanResultBlock)callback {
-    [self openWithClientId:clientId security:YES tag:nil force:NO callback:callback];
-}
-
-- (void)openWithClientId:(NSString *)clientId tag:(NSString *)tag callback:(AVIMBooleanResultBlock)callback {
-    [self openWithClientId:clientId security:YES tag:tag force:NO callback:callback];
 }
 
 - (void)openWithClientId:(NSString *)clientId security:(BOOL)security tag:(NSString *)tag force:(BOOL)force callback:(AVIMBooleanResultBlock)callback {

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -160,6 +160,10 @@ static BOOL AVIMClientHasInstantiated = NO;
     return self;
 }
 
+- (instancetype)initWithUser:(AVUser *)user {
+    return [self initWithUser:user tag:nil];
+}
+
 - (instancetype)initWithUser:(AVUser *)user tag:(NSString *)tag {
     self = [super init];
 


### PR DESCRIPTION
支持用 user 登录 IM。

新增接口：

```objc
- initWithUser:
- initWithUser:tag:
```

移除接口：

```objc
- openWithClientId:callback:
- openWithClientId:tag:callback:
+ defaultClient
+ resetDefaultClient
```

使用 AVUser 登录 IM 的示例代码：

```objc
AVIMClient *client = [[AVIMClient alloc] initWithUser:user];

[client openWithCallback:^(BOOL succeeded, NSError *error) {
    /* Do something. */
}];
```

@leancloud/ios-group
@leancloud/android-group
@leancloud/javascript-group 

PTAL