### PR TITLE
Remove X-LC-Sign header from curl log

### DIFF
--- a/AVOS/AVOSCloud/Request/AVPaasClient.m
+++ b/AVOS/AVOSCloud/Request/AVPaasClient.m
@@ -87,8 +87,13 @@ NSString *const LCHeaderFieldNameProduction = @"X-LC-Prod";
             [command appendCommandLineArgument:[NSString stringWithFormat:@"--cookie \"%@=%@\"", [cookie name], [cookie value]]];
         }
     }
+
+    NSMutableDictionary<NSString *, NSString *> *headers = [[self allHTTPHeaderFields] mutableCopy];
+
+    /* Remove signature for security. */
+    [headers removeObjectForKey:@"X-LC-Sign"];
     
-    for (id field in [self allHTTPHeaderFields]) {
+    for (NSString * field in headers) {
         [command appendCommandLineArgument:[NSString stringWithFormat:@"-H %@", [NSString stringWithFormat:@"'%@: %@'", field, [[self valueForHTTPHeaderField:field] stringByReplacingOccurrencesOfString:@"\'" withString:@"\\\'"]]]];
     }
 


### PR DESCRIPTION
删除 curl 请求日志中的签名，防止恶意用户利用它来构造请求。