### PR TITLE
Increase unread count when receive message

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -1357,18 +1357,6 @@ static BOOL AVIMClientHasInstantiated = NO;
     __weak typeof(self) ws = self;
     
     [self fetchConversationIfNeeded:conversation withBlock:^(AVIMConversation *conversation) {
-        /* Update lastMessageAt if needed. */
-        NSDate *messageSentAt = [NSDate dateWithTimeIntervalSince1970:(message.sendTimestamp / 1000.0)];
-        if (!message.transient) {
-            if (!conversation.lastMessageAt || [conversation.lastMessageAt compare:messageSentAt] == NSOrderedAscending) {
-                conversation.lastMessageAt = messageSentAt;
-            }
-            LCIM_NOTIFY_PROPERTY_UPDATE(
-                ws.clientId,
-                conversationId,
-                NSStringFromSelector(@selector(lastMessage)),
-                message);
-        }
         [ws passMessage:message toConversation:conversation];
         [ws postNotificationForMessage:message];
     }];


### PR DESCRIPTION
当收到消息时，更新对话的 lastMessage, lastMessageAt, 以及 unreadMessagesCount 三个属性，并发出事件通知。之前处理不完善，导致 lastMessage 和 unreadMessagesCount 没有更新事件产生。