### PR TITLE
Synthesize properties of dynamic object explicitly

### DIFF
--- a/AVOS/AVOSCloudIM/InternalObjects/AVIMGeneralObject.h
+++ b/AVOS/AVOSCloudIM/InternalObjects/AVIMGeneralObject.h
@@ -9,16 +9,16 @@
 #import "AVIMDynamicObject.h"
 
 @interface AVIMGeneralObject : AVIMDynamicObject
-@property(nonatomic)uint width;
-@property(nonatomic)uint height;
-@property(nonatomic)uint64_t size;
-@property(nonatomic)float duration;
-@property(nonatomic, strong)NSString *name;
-@property(nonatomic, strong)NSString *format;
-@property(nonatomic, strong)NSString *url;
-@property(nonatomic, strong)NSString *objId;
-@property(nonatomic)float longitude;
-@property(nonatomic)float latitude;
-@property(nonatomic, strong)AVIMGeneralObject *metaData;
-@property(nonatomic, strong)AVIMGeneralObject *location;
+@property(nonatomic, assign) uint width;
+@property(nonatomic, assign) uint height;
+@property(nonatomic, assign) uint64_t size;
+@property(nonatomic, assign) float duration;
+@property(nonatomic,   copy) NSString *name;
+@property(nonatomic,   copy) NSString *format;
+@property(nonatomic,   copy) NSString *url;
+@property(nonatomic,   copy) NSString *objId;
+@property(nonatomic, assign) float longitude;
+@property(nonatomic, assign) float latitude;
+@property(nonatomic, strong) AVIMGeneralObject *metaData;
+@property(nonatomic, strong) AVIMGeneralObject *location;
 @end

--- a/AVOS/AVOSCloudIM/InternalObjects/AVIMGeneralObject.m
+++ b/AVOS/AVOSCloudIM/InternalObjects/AVIMGeneralObject.m
@@ -9,5 +9,18 @@
 #import "AVIMGeneralObject.h"
 
 @implementation AVIMGeneralObject
-@dynamic width, height, size, duration, name, format, longitude, latitude, location, metaData, objId, url;
+
+LC_FORWARD_PROPERTY_ACCESSOR_NUMBER         (width,     setWidth, uint)
+LC_FORWARD_PROPERTY_ACCESSOR_NUMBER         (height,    setHeight, uint)
+LC_FORWARD_PROPERTY_ACCESSOR_NUMBER         (size,      setSize, uint64_t)
+LC_FORWARD_PROPERTY_ACCESSOR_NUMBER         (duration,  setDuration, float)
+LC_FORWARD_PROPERTY_ACCESSOR_OBJECT_COPY    (name,      setName)
+LC_FORWARD_PROPERTY_ACCESSOR_OBJECT_COPY    (format,    setFormat)
+LC_FORWARD_PROPERTY_ACCESSOR_OBJECT_COPY    (url,       setUrl)
+LC_FORWARD_PROPERTY_ACCESSOR_OBJECT_COPY    (objId,     setObjId)
+LC_FORWARD_PROPERTY_ACCESSOR_NUMBER         (longitude, setLongitude, float)
+LC_FORWARD_PROPERTY_ACCESSOR_NUMBER         (latitude,  setLatitude, float)
+LC_FORWARD_PROPERTY_ACCESSOR_OBJECT         (metaData, setMetaData)
+LC_FORWARD_PROPERTY_ACCESSOR_OBJECT         (location, setLocation)
+
 @end


### PR DESCRIPTION
用显式地定义的 getter 和 setter 取代 dynamic 属性，避免运行时动态生成 accessor 的不稳定性。
之前有用户反馈另一个类有同样的问题，当时也是这样解决的，后来没有再收到那个问题的反馈。