### PR TITLE
Check nullability of id when get conversation by id

### DIFF
--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -216,6 +216,9 @@ static BOOL AVIMClientHasInstantiated = NO;
 }
 
 - (AVIMConversation *)conversationForId:(NSString *)conversationId {
+    if (!conversationId)
+        return nil;
+
     AVIMConversation *conversation = [_conversations objectForKey:conversationId];
 
     /* Disable conversation cache for consistent */


### PR DESCRIPTION
关联工单 https://leanticket.cn/tickets/14332 。

在 conversationForId 方法中检查 conversationId 的 nullability，以防止 crash。

@leancloud/ios-group 