### PR TITLE
Remove unnecessary error checking for rpc

### DIFF
--- a/AVOS/AVOSCloud/CloudCode/AVCloud.m
+++ b/AVOS/AVOSCloud/CloudCode/AVCloud.m
@@ -133,14 +133,8 @@
     [[AVPaasClient sharedInstance]
      performRequest:request
      success:^(NSHTTPURLResponse *response, id responseObject) {
-         NSError *error = [AVErrorUtils errorFromJSON:responseObject];
-
-         if (error) {
-             [AVUtils callIdResultBlock:block object:nil error:error];
-         } else {
-             id result = [self processedFunctionResultFromObject:responseObject[@"result"]];
-             [AVUtils callIdResultBlock:block object:result error:nil];
-         }
+         id result = [self processedFunctionResultFromObject:responseObject[@"result"]];
+         [AVUtils callIdResultBlock:block object:result error:nil];
      }
      failure:^(NSHTTPURLResponse *response, id responseObject, NSError *inError) {
          NSError *error = [AVErrorUtils errorFromJSON:responseObject] ?: inError;


### PR DESCRIPTION
移除 rpc 请求返回正常时多余的错误检查。

背景：早期 SDK 会递归解析正常 HTTP 响应数据中的字段，如果存在名为 "error" 或 "code" 的 key，就会当做失败。REST API 已经不会在 200 的请求中包含错误信息，只要响应正常，客户端都不应该做错误检查。SDK 应该尊重 HTTP 状态码。

@leancloud/ios-group 