### PR TITLE
Fix/do not pollute documents directory

### DIFF
--- a/AVOS/AVOSCloud/Cache/AVPersistenceUtils.h
+++ b/AVOS/AVOSCloud/Cache/AVPersistenceUtils.h
@@ -23,7 +23,6 @@
 + (NSString *)messageCacheDatabasePathWithName:(NSString *)name;
 
 + (NSString *)keyValueDatabasePath;
-+ (NSString *)commandCacheDatabasePath;
 + (NSString *)clientSessionTokenCacheDatabasePath;
 
 + (NSString *)userDefaultsPath;

--- a/AVOS/AVOSCloud/Cache/AVPersistenceUtils.m
+++ b/AVOS/AVOSCloud/Cache/AVPersistenceUtils.m
@@ -38,42 +38,6 @@
 
 #pragma mark - ~/Documents
 
-// ~/Documents
-+ (NSString *)appDocumentPath {
-    static NSString *path = nil;
-    
-    if (!path) {
-        path = [[self homeDirectoryPath] stringByAppendingPathComponent:@"Documents"];
-    }
-    
-    return path;
-}
-
-// ~/Documents/LeanCloud
-+ (NSString *)leanDocumentPath {
-    NSString *path = [self appDocumentPath];
-    
-    path = [path stringByAppendingPathComponent:LCRootDirName];
-    
-    [self createDirectoryIfNeeded:path];
-    
-    return path;
-}
-
-// ~/Documents/LeanCloud/keyvalue
-+ (NSString *)keyValueDatabasePath {
-    return [[self leanDocumentPath] stringByAppendingPathComponent:@"keyvalue"];
-}
-
-// ~/Documents/LeanCloud/CommandCache
-+ (NSString *)commandCacheDatabasePath {
-    return [[self leanDocumentPath] stringByAppendingPathComponent:@"CommandCache"];
-}
-
-+ (NSString *)clientSessionTokenCacheDatabasePath {
-    return [[self leanDocumentPath] stringByAppendingPathComponent:@"ClientSessionToken"];
-}
-
 // ~/Library/Caches/LeanCloud/{applicationId}
 + (NSString *)cacheSandboxPath {
     NSString *applicationId = [AVOSCloud getApplicationId];
@@ -87,6 +51,21 @@
     [self createDirectoryIfNeeded:sandboxPath];
 
     return sandboxPath;
+}
+
+// ~/Library/Caches/LeanCloud/{applicationId}/KeyValue
++ (NSString *)keyValueDatabasePath {
+    return [[self cacheSandboxPath] stringByAppendingPathComponent:@"KeyValue"];
+}
+
+// ~/Library/Caches/LeanCloud/{applicationId}/CommandCache
++ (NSString *)commandCacheDatabasePath {
+    return [[self cacheSandboxPath] stringByAppendingPathComponent:@"CommandCache"];
+}
+
+// ~/Library/Caches/LeanCloud/{applicationId}/ClientSessionToken
++ (NSString *)clientSessionTokenCacheDatabasePath {
+    return [[self cacheSandboxPath] stringByAppendingPathComponent:@"ClientSessionToken"];
 }
 
 // ~/Library/Caches/LeanCloud/{applicationId}/UserDefaults

--- a/AVOS/AVOSCloud/Cache/AVPersistenceUtils.m
+++ b/AVOS/AVOSCloud/Cache/AVPersistenceUtils.m
@@ -58,11 +58,6 @@
     return [[self cacheSandboxPath] stringByAppendingPathComponent:@"KeyValue"];
 }
 
-// ~/Library/Caches/LeanCloud/{applicationId}/CommandCache
-+ (NSString *)commandCacheDatabasePath {
-    return [[self cacheSandboxPath] stringByAppendingPathComponent:@"CommandCache"];
-}
-
 // ~/Library/Caches/LeanCloud/{applicationId}/ClientSessionToken
 + (NSString *)clientSessionTokenCacheDatabasePath {
     return [[self cacheSandboxPath] stringByAppendingPathComponent:@"ClientSessionToken"];

--- a/AVOS/AVOSCloudTests/LogicTests/AVPersistentUtilsTest.m
+++ b/AVOS/AVOSCloudTests/LogicTests/AVPersistentUtilsTest.m
@@ -42,9 +42,4 @@
     [self assertPath:path equalToRelativePath:@"~/Library/Caches/LeanCloud/MessageCache/chat"];
 }
 
-- (void)testCommandCacheDatabasePath {
-    NSString *path = [AVPersistenceUtils commandCacheDatabasePath];
-    [self assertPath:path equalToRelativePath:@"~/Documents/LeanCloud/CommandCache"];
-}
-
 @end


### PR DESCRIPTION
防止 Documents 目录被 SDK 污染。

由于 Documents 目录是共享目录，SDK 不应该将任何数据放到这个目录中。

这个 PR 仅仅改变了缓存路径，没有做拷贝迁移。这会导致升级 SDK 后，旧的部分缓存数据过期，这部分数据包括：

1. 网络统计数据；
2. IM 的 session token。

庆幸的是这两种数据都不是非常关键的数据。之前的网络统计数据可以扔掉，session token 丢失 IM 也能正常工作。

另外，SDK 不主动清除 Documents 目录下的数据，app 需要自己清除。

@leancloud/ios-group 