### PR TITLE
Fix some build warning & crash when parse error from JSON

### DIFF
--- a/AVOS/AVOS.xcodeproj/project.pbxproj
+++ b/AVOS/AVOS.xcodeproj/project.pbxproj
@@ -4091,7 +4091,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = AV;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = "LeanCloud Inc.";
 				TargetAttributes = {
 					704F3B6D1BE0D0180033245C = {
@@ -5463,6 +5463,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 3;
 				DEFINES_MODULE = YES;
@@ -5498,6 +5499,7 @@
 					"$(inherited)",
 					"-lsqlite3",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.avoscloud.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AVOSCloud;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = watchos;
@@ -5528,6 +5530,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 3;
 				DEFINES_MODULE = YES;
@@ -5556,6 +5559,7 @@
 					"$(inherited)",
 					"-lsqlite3",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.avoscloud.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AVOSCloud;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = watchos;
@@ -5653,7 +5657,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -6028,6 +6032,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -6098,6 +6103,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -6150,6 +6156,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 3;
 				DEFINES_MODULE = YES;
@@ -6185,6 +6192,7 @@
 					"$(inherited)",
 					"-lsqlite3",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.avoscloud.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AVOSCloud;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = appletvos;
@@ -6215,6 +6223,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 3;
@@ -6244,6 +6253,7 @@
 					"$(inherited)",
 					"-lsqlite3",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.avoscloud.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AVOSCloud;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = appletvos;
@@ -6275,6 +6285,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 3;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -6310,7 +6321,7 @@
 				);
 				INFOPLIST_FILE = "Resources/$(TARGET_NAME).info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6319,6 +6330,7 @@
 				MACH_O_TYPE = staticlib;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.avoscloud.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AVOSCloudCrashReporting;
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
@@ -6347,7 +6359,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 3;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -6376,7 +6388,7 @@
 				);
 				INFOPLIST_FILE = "Resources/$(TARGET_NAME).info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6385,6 +6397,7 @@
 				MACH_O_TYPE = staticlib;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.avoscloud.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AVOSCloudCrashReporting;
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
@@ -6398,12 +6411,36 @@
 		8C84197F1A5A78E100C5C6C4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DYLIB_COMPATIBILITY_VERSION = 2;
 				DYLIB_CURRENT_VERSION = 3.0;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "";
@@ -6420,11 +6457,34 @@
 		8C8419801A5A78E100C5C6C4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Meiwei Shuqian(Beijing) Information Technology co., LTD (Y6X8P44TM5)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Meiwei Shuqian(Beijing) Information Technology co., LTD (Y6X8P44TM5)";
 				DYLIB_COMPATIBILITY_VERSION = 2;
 				DYLIB_CURRENT_VERSION = 3.0;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
@@ -6456,7 +6516,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 3;
 				DEFINES_MODULE = YES;
@@ -6481,7 +6541,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Resources/$(TARGET_NAME).info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6522,7 +6582,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 3;
 				DEFINES_MODULE = YES;
@@ -6540,7 +6600,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Resources/$(TARGET_NAME).info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -6610,6 +6670,7 @@
 					"$(inherited)",
 					"-lz",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "cn.leancloud.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 			};
@@ -6654,6 +6715,7 @@
 					"$(inherited)",
 					"-lz",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "cn.leancloud.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 			};
@@ -6678,7 +6740,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 3;
 				DEFINES_MODULE = YES;
@@ -6704,12 +6766,13 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/AVOSCloudIM/Protobuf";
 				INFOPLIST_FILE = "Resources/$(TARGET_NAME).info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MACH_O_TYPE = staticlib;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.avoscloud.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AVOSCloudIM;
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
@@ -6738,7 +6801,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 3;
 				DEFINES_MODULE = YES;
@@ -6757,12 +6820,13 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/AVOSCloudIM/Protobuf";
 				INFOPLIST_FILE = "Resources/$(TARGET_NAME).info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MACH_O_TYPE = staticlib;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.avoscloud.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AVOSCloudIM;
 				PROVISIONING_PROFILE = "";
 				SKIP_INSTALL = YES;
@@ -6818,6 +6882,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "cn.leancloud.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
@@ -6862,6 +6927,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = "cn.leancloud.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloud-iOS.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloud-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -60,6 +61,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloud-iOSTests.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloud-iOSTests.xcscheme
@@ -1,15 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8C8419901A5A791300C5C6C4"
+               BuildableName = "AVOSCloud-iOSTests.xctest"
+               BlueprintName = "AVOSCloud-iOSTests"
+               ReferencedContainer = "container:AVOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -30,12 +47,22 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8C8419901A5A791300C5C6C4"
+            BuildableName = "AVOSCloud-iOSTests.xctest"
+            BlueprintName = "AVOSCloud-iOSTests"
+            ReferencedContainer = "container:AVOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -45,6 +72,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8C8419901A5A791300C5C6C4"
+            BuildableName = "AVOSCloud-iOSTests.xctest"
+            BlueprintName = "AVOSCloud-iOSTests"
+            ReferencedContainer = "container:AVOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloud-macOS.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloud-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -55,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloud-macOSTests.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloud-macOSTests.xcscheme
@@ -1,15 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "70F315311BDE503B00D691B3"
+               BuildableName = "AVOSCloud-macOSTests.xctest"
+               BlueprintName = "AVOSCloud-macOSTests"
+               ReferencedContainer = "container:AVOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -30,12 +47,22 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "70F315311BDE503B00D691B3"
+            BuildableName = "AVOSCloud-macOSTests.xctest"
+            BlueprintName = "AVOSCloud-macOSTests"
+            ReferencedContainer = "container:AVOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -45,6 +72,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "70F315311BDE503B00D691B3"
+            BuildableName = "AVOSCloud-macOSTests.xctest"
+            BlueprintName = "AVOSCloud-macOSTests"
+            ReferencedContainer = "container:AVOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloud-tvOS.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloud-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -36,6 +37,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloud-watchOS.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloud-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -36,6 +37,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudCrashReporting-iOS.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudCrashReporting-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -36,6 +37,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudIM-iOS.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudIM-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -55,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudIM-iOSTests.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudIM-iOSTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -10,6 +10,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -30,6 +31,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudIM-macOS.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudIM-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -55,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudIM-macOSTests.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudIM-macOSTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -10,6 +10,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -30,6 +31,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudLiveQuery-iOS.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudLiveQuery-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -36,6 +37,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudLiveQuery-iOSTests.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudLiveQuery-iOSTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -10,6 +10,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -30,6 +31,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudLiveQuery-macOS.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudLiveQuery-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -36,6 +37,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudLiveQuery-macOSTests.xcscheme
+++ b/AVOS/AVOS.xcodeproj/xcshareddata/xcschemes/AVOSCloudLiveQuery-macOSTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0830"
+   LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -10,6 +10,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -30,6 +31,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/AVOS/AVOSCloud/Request/AVPaasClient.m
+++ b/AVOS/AVOSCloud/Request/AVPaasClient.m
@@ -522,7 +522,6 @@ NSString *const LCHeaderFieldNameProduction = @"X-LC-Prod";
 
 - (void)performRequest:(NSURLRequest *)request saveResult:(BOOL)saveResult block:(AVIdResultBlock)block retryTimes:(NSInteger)retryTimes {
     NSURL *URL = request.URL;
-    NSString *path = URL.path;
     NSString *URLString = URL.absoluteString;
     NSMutableURLRequest *mutableRequest = [request mutableCopy];
 

--- a/AVOS/AVOSCloud/ThirdParty/COSObserver/LCObserver.m
+++ b/AVOS/AVOSCloud/ThirdParty/COSObserver/LCObserver.m
@@ -233,7 +233,8 @@ void cos_hook_object_if_needed(NSObject *object) {
         [_target removeObserver:self forKeyPath:_keyPath context:cos_context];
     }
 
-    [cos_observation_pool(_target) removeObject:self], _target = nil;
+    [cos_observation_pool(_target) removeObject:self];
+    _target = nil;
     [cos_observation_pool(_object) removeObject:self];
 }
 

--- a/AVOS/AVOSCloud/ThirdParty/libextobjc/EXTScope.h
+++ b/AVOS/AVOSCloud/ThirdParty/libextobjc/EXTScope.h
@@ -33,7 +33,7 @@
     __strong ext_cleanupBlock_t metamacro_concat(ext_exitBlock_, __LINE__) __attribute__((cleanup(lc_executeCleanupBlock), unused)) = ^
 
 /*** implementation details follow ***/
-typedef void (^ext_cleanupBlock_t)();
+typedef void (^ext_cleanupBlock_t)(void);
 
 #if defined(__cplusplus)
 extern "C" {

--- a/AVOS/AVOSCloud/User/AVUser.m
+++ b/AVOS/AVOSCloud/User/AVUser.m
@@ -619,7 +619,7 @@ static BOOL enableAutomatic = NO;
     }];
 }
 
-+ (instancetype)becomeWithSessionToken:(NSString *)sessionToken error:(NSError **)error {
++ (instancetype)becomeWithSessionToken:(NSString *)sessionToken error:(NSError * __autoreleasing *)error {
     __block Boolean hasCallback = NO;
     __block AVUser *user;
     [self internalBecomeWithSessionTokenInBackground:sessionToken block:^(AVUser *theUser, NSError *theError) {

--- a/AVOS/AVOSCloud/User/AVUser_Internal.h
+++ b/AVOS/AVOSCloud/User/AVUser_Internal.h
@@ -31,7 +31,5 @@
 -(NSString *)internalClassName;
 -(void)setNewFlag:(BOOL)isNew;
 
-+(void)removeCookies;
-
 - (NSArray *)linkedServiceNames;
 @end

--- a/AVOS/AVOSCloud/Utils/AVDynamicObject.m
+++ b/AVOS/AVOSCloud/Utils/AVDynamicObject.m
@@ -169,7 +169,11 @@ static void setter_selector(id self, SEL _cmd, SEL value) {
 
 NS_INLINE
 BOOL hasProperty(id object, NSString *name) {
-    return class_getProperty(object_getClass(object), name.UTF8String);
+    if (class_getProperty(object_getClass(object), name.UTF8String)) {
+        return TRUE;
+    } else {
+        return FALSE;
+    }
 }
 
 NS_INLINE

--- a/AVOS/AVOSCloud/Utils/AVErrorUtils.m
+++ b/AVOS/AVOSCloud/Utils/AVErrorUtils.m
@@ -129,17 +129,21 @@ NSInteger const kAVErrorFileDataNotAvailable = 401;
 }
 
 +(NSError *)errorWithCode:(NSInteger)code errorText:(NSString *)text {
-    if (!code) { code = 0; }
-    NSDictionary *errorInfo=@{
-                                @"code":@(code),
-                                @"error":text, //???: should we remove this key
-                                NSLocalizedDescriptionKey:NSLocalizedString(text, nil), //TODO: add localized error descriptions
-                            };
+    if (!code) {
+        code = 0;
+    }
+    
+    NSString *localizedString = NSLocalizedString(text, nil);
+    
+    NSDictionary *errorInfo = @{
+                                @"code" : @(code),
+                                @"error" : text, //???: should we remove this key
+                                NSLocalizedDescriptionKey : localizedString //TODO: add localized error descriptions
+                                };
     
     NSError *err= [NSError errorWithDomain:kAVErrorDomain
                                code:code
                            userInfo:errorInfo];
-    
     
     return err;
 }
@@ -229,26 +233,25 @@ NSInteger const kAVErrorFileDataNotAvailable = 401;
     
     NSString *errorString = [dic objectForKey:@"error"];
     NSNumber *code = [dic objectForKey:@"code"];
-    if (!code || ((id)code == [NSNull null])) {
+    if (code == NULL) {
         code = @(kAVErrorUnknownErrorCode);
     }
-    if (!errorString || ((id)errorString == [NSNull null])) {
+    if (errorString == NULL) {
         errorString = [NSString stringWithFormat:@"%@, `code` and `error` are reserved keys.", kAVErrorUnknownText];
     }
     return [AVErrorUtils errorWithCode:code.integerValue errorText:errorString];
 }
 
 + (BOOL)_isDictionaryError:(NSDictionary *)dic {
-    NSString *errorString = [dic objectForKey:@"error"];
-    NSNumber *code = [dic objectForKey:@"code"];
-    if (((id)code == [NSNull null]) && ((id)errorString == [NSNull null])) {
-        return NO;
-    }
-    if (code) {
+    
+    id errorString = [dic objectForKey:@"error"];
+    id code = [dic objectForKey:@"code"];
+    
+    if (code && [code isKindOfClass:[NSNumber class]]) {
         return YES;
     }
     
-    if (errorString) {
+    if (errorString && [errorString isKindOfClass:[NSString class]]) {
         return YES;
     }
     

--- a/AVOS/AVOSCloud/Utils/AVUtils.h
+++ b/AVOS/AVOSCloud/Utils/AVUtils.h
@@ -107,7 +107,7 @@ SecCertificateRef LCGetCertificateFromBase64String(NSString *base64);
 
  @param task The task to be dispatched.
  */
-+ (void)asynchronizeTask:(void(^)())task;
++ (void)asynchronizeTask:(void(^)(void))task;
 
 #pragma mark - String Util
 + (NSString *)MIMEType:(NSString *)filePathOrName;

--- a/AVOS/AVOSCloud/Utils/AVUtils.m
+++ b/AVOS/AVOSCloud/Utils/AVUtils.m
@@ -529,7 +529,7 @@ if (block) { \
     return queue;
 }
 
-+ (void)asynchronize:(void (^)())task {
++ (void)asynchronizeTask:(void (^)(void))task {
     NSAssert(task != nil, @"Task cannot be nil.");
 
     dispatch_async([self asynchronousTaskQueue], ^{

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -842,7 +842,12 @@ static BOOL AVIMClientHasInstantiated = NO;
         }];
 
         AVIMSessionCommand *sessionCommand = [[AVIMSessionCommand alloc] init];
-        sessionCommand.sessionPeerIdsArray = clients ?: @[];
+        
+        NSMutableArray<NSString *> *sessionPeerIdsArray = [NSMutableArray new];
+        if (clients) {
+            [sessionPeerIdsArray addObjectsFromArray:clients];
+        }
+        sessionCommand.sessionPeerIdsArray = sessionPeerIdsArray;
 
         [genericCommand avim_addRequiredKeyWithCommand:sessionCommand];
 
@@ -1060,8 +1065,13 @@ static BOOL AVIMClientHasInstantiated = NO;
         [self updateConversation:conversationId withDictionary:dictionary];
 
         /* For compatibility, we reserve this callback. It should be removed in future. */
-        if ([self.delegate respondsToSelector:@selector(conversation:didReceiveUnread:)])
+        SEL selector = @selector(conversation:didReceiveUnread:);
+        if ([self.delegate respondsToSelector:selector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             [self.delegate conversation:conversation didReceiveUnread:unreadTuple.unread];
+#pragma clang diagnostic pop
+        }
     }];
 }
 
@@ -1480,9 +1490,11 @@ static BOOL AVIMClientHasInstantiated = NO;
 }
 
 + (void)setUnreadNotificationEnabled:(BOOL)enabled {
-    [self setUserOptions:@{
-        AVIMUserOptionUseUnread: @(enabled)
-    }];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    NSDictionary *options = @{ AVIMUserOptionUseUnread : @(enabled) };
+    [self setUserOptions:options];
+#pragma clang diagnostic pop
 }
 
 @end

--- a/AVOS/AVOSCloudIM/AVIMConversation.m
+++ b/AVOS/AVOSCloudIM/AVIMConversation.m
@@ -1041,10 +1041,10 @@ static dispatch_queue_t messageCacheOperationQueue;
         patchItem.mentionPidsArray = [newMessage.mentionList mutableCopy];
     }
 
-    NSMutableArray *patchesArray = @[patchItem];
+    NSArray<AVIMPatchItem*> *patchesArray = @[patchItem];
     AVIMPatchCommand *patchMessage = [[AVIMPatchCommand alloc] init];
 
-    patchMessage.patchesArray = patchesArray;
+    patchMessage.patchesArray = [patchesArray mutableCopy];
     command.patchMessage = patchMessage;
 
     return command;
@@ -1218,7 +1218,11 @@ static dispatch_queue_t messageCacheOperationQueue;
 
 - (void)sendACKIfNeeded:(NSArray *)messages {
     NSDictionary *userOptions = [AVIMClient userOptions];
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     BOOL useUnread = [userOptions[AVIMUserOptionUseUnread] boolValue];
+#pragma clang diagnostic pop
     
     if (useUnread) {
         AVIMClient *client = self.imClient;
@@ -1305,7 +1309,10 @@ static dispatch_queue_t messageCacheOperationQueue;
     logsCommand.cid    = _conversationId;
     logsCommand.mid    = messageId;
     logsCommand.t      = LCIM_VALID_TIMESTAMP(timestamp);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     logsCommand.l      = LCIM_VALID_LIMIT(limit);
+#pragma clang diagnostic pop
     
     [genericCommand avim_addRequiredKeyWithCommand:logsCommand];
     [self queryMessagesFromServerWithCommand:genericCommand callback:callback];
@@ -1328,7 +1335,10 @@ static dispatch_queue_t messageCacheOperationQueue;
     logsCommand.tmid   = toMessageId;
     logsCommand.tt     = MAX(toTimestamp, 0);
     logsCommand.t      = MAX(timestamp, 0);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     logsCommand.l      = LCIM_VALID_LIMIT(limit);
+#pragma clang diagnostic pop
     [genericCommand avim_addRequiredKeyWithCommand:logsCommand];
     [self queryMessagesFromServerWithCommand:genericCommand callback:callback];
 }
@@ -1336,7 +1346,10 @@ static dispatch_queue_t messageCacheOperationQueue;
 - (void)queryMessagesFromServerWithLimit:(NSUInteger)limit
                                 callback:(AVIMArrayResultBlock)callback
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     limit = LCIM_VALID_LIMIT(limit);
+#pragma clang diagnostic pop
     
     [self queryMessagesFromServerBeforeId:nil
                                 timestamp:LCIM_DISTANT_FUTURE_TIMESTAMP
@@ -1355,7 +1368,10 @@ static dispatch_queue_t messageCacheOperationQueue;
 }
 
 - (NSArray *)queryMessagesFromCacheWithLimit:(NSUInteger)limit {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     limit = LCIM_VALID_LIMIT(limit);
+#pragma clang diagnostic pop
     NSArray *cachedMessages = [[self messageCacheStore] latestMessagesWithLimit:limit];
     [self postprocessMessages:cachedMessages];
     
@@ -1365,7 +1381,10 @@ static dispatch_queue_t messageCacheOperationQueue;
 - (void)queryMessagesWithLimit:(NSUInteger)limit
                       callback:(AVIMArrayResultBlock)callback
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     limit = LCIM_VALID_LIMIT(limit);
+#pragma clang diagnostic pop
     
     BOOL socketOpened = self.imClient.status == AVIMClientStatusOpened;
     // 如果屏蔽了本地缓存则全部走网络
@@ -1415,7 +1434,10 @@ static dispatch_queue_t messageCacheOperationQueue;
                         limit:(NSUInteger)limit
                      callback:(AVIMArrayResultBlock)callback
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     limit     = LCIM_VALID_LIMIT(limit);
+#pragma clang diagnostic pop
     timestamp = LCIM_VALID_TIMESTAMP(timestamp);
 
     /*
@@ -1551,7 +1573,10 @@ static dispatch_queue_t messageCacheOperationQueue;
     AVIMLogsCommand *logsCommand = [[AVIMLogsCommand alloc] init];
 
     logsCommand.cid  = _conversationId;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     logsCommand.l    = LCIM_VALID_LIMIT(limit);
+#pragma clang diagnostic pop
 
     logsCommand.direction = (direction == AVIMMessageQueryDirectionFromOldToNew)
         ? AVIMLogsCommand_QueryDirection_New

--- a/AVOS/AVOSCloudIM/Commands/AVIMCommandFormatter.m
+++ b/AVOS/AVOSCloudIM/Commands/AVIMCommandFormatter.m
@@ -16,7 +16,7 @@ const NSInteger LCIMErrorCodeSessionTokenExpired = 4112;
 @implementation AVIMCommandFormatter
 
 + (NSString *)commandType:(AVIMCommandType)commandType {
-    NSString *commandTypeString;
+    NSString *commandTypeString = nil;
     switch (commandType) {
         case AVIMCommandType_Session:
             commandTypeString = @"Session";
@@ -72,6 +72,9 @@ const NSInteger LCIMErrorCodeSessionTokenExpired = 4112;
             
         case AVIMCommandType_Report:
             commandTypeString = @"Report";
+            break;
+            
+        default:
             break;
     }
     return commandTypeString;

--- a/AVOS/AVOSCloudIM/Commands/AVIMGenericCommand+AVIMMessagesAdditions.h
+++ b/AVOS/AVOSCloudIM/Commands/AVIMGenericCommand+AVIMMessagesAdditions.h
@@ -22,7 +22,7 @@ typedef void (^AVIMCommandResultBlock)(AVIMGenericCommand *outCommand, AVIMGener
 
 /*!
  序列化时必须要调用。为AVIMGenericCommand对象添加必要的三个字段：needResponse、SerialId、messageObject，，在command完全初始化之后调用
- @param commmand 具体的Command对象
+ @param command 具体的Command对象
  *
  */
 - (void)avim_addRequiredKeyWithCommand:(LCIMMessage *)command;

--- a/AVOS/AVOSCloudIM/Commands/AVIMGenericCommand+AVIMMessagesAdditions.m
+++ b/AVOS/AVOSCloudIM/Commands/AVIMGenericCommand+AVIMMessagesAdditions.m
@@ -93,6 +93,9 @@ static uint16_t _searial_id = 0;
         case AVIMCommandType_Report:
             self.reportMessage = (AVIMReportCommand *)command;
             break;
+            
+        default:
+            break;
     }
 }
 
@@ -425,6 +428,9 @@ static uint16_t _searial_id = 0;
             
         case AVIMCommandType_Report:
             result = self.reportMessage;
+            break;
+            
+        default:
             break;
     }
     return result;

--- a/AVOS/AVOSCloudIM/Protobuf/LCIMArray.h
+++ b/AVOS/AVOSCloudIM/Protobuf/LCIMArray.h
@@ -96,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized LCIMInt32Array with a copy of the values.
  **/
-- (instancetype)initWithValues:(const int32_t [])values
+- (instancetype)initWithValues:(const int32_t [_Nullable])values
                          count:(NSUInteger)count;
 
 /**
@@ -161,7 +161,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param values The values to add to this array.
  * @param count  The number of elements to add.
  **/
-- (void)addValues:(const int32_t [])values count:(NSUInteger)count;
+- (void)addValues:(const int32_t [_Nullable])values count:(NSUInteger)count;
 
 /**
  * Adds the values from the given array to this array.
@@ -268,7 +268,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized LCIMUInt32Array with a copy of the values.
  **/
-- (instancetype)initWithValues:(const uint32_t [])values
+- (instancetype)initWithValues:(const uint32_t [_Nullable])values
                          count:(NSUInteger)count;
 
 /**
@@ -333,7 +333,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param values The values to add to this array.
  * @param count  The number of elements to add.
  **/
-- (void)addValues:(const uint32_t [])values count:(NSUInteger)count;
+- (void)addValues:(const uint32_t [_Nullable])values count:(NSUInteger)count;
 
 /**
  * Adds the values from the given array to this array.
@@ -440,7 +440,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized LCIMInt64Array with a copy of the values.
  **/
-- (instancetype)initWithValues:(const int64_t [])values
+- (instancetype)initWithValues:(const int64_t [_Nullable])values
                          count:(NSUInteger)count;
 
 /**
@@ -505,7 +505,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param values The values to add to this array.
  * @param count  The number of elements to add.
  **/
-- (void)addValues:(const int64_t [])values count:(NSUInteger)count;
+- (void)addValues:(const int64_t [_Nullable])values count:(NSUInteger)count;
 
 /**
  * Adds the values from the given array to this array.
@@ -612,7 +612,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized LCIMUInt64Array with a copy of the values.
  **/
-- (instancetype)initWithValues:(const uint64_t [])values
+- (instancetype)initWithValues:(const uint64_t [_Nullable])values
                          count:(NSUInteger)count;
 
 /**
@@ -677,7 +677,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param values The values to add to this array.
  * @param count  The number of elements to add.
  **/
-- (void)addValues:(const uint64_t [])values count:(NSUInteger)count;
+- (void)addValues:(const uint64_t [_Nullable])values count:(NSUInteger)count;
 
 /**
  * Adds the values from the given array to this array.
@@ -784,7 +784,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized LCIMFloatArray with a copy of the values.
  **/
-- (instancetype)initWithValues:(const float [])values
+- (instancetype)initWithValues:(const float [_Nullable])values
                          count:(NSUInteger)count;
 
 /**
@@ -849,7 +849,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param values The values to add to this array.
  * @param count  The number of elements to add.
  **/
-- (void)addValues:(const float [])values count:(NSUInteger)count;
+- (void)addValues:(const float [_Nullable])values count:(NSUInteger)count;
 
 /**
  * Adds the values from the given array to this array.
@@ -956,7 +956,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized LCIMDoubleArray with a copy of the values.
  **/
-- (instancetype)initWithValues:(const double [])values
+- (instancetype)initWithValues:(const double [_Nullable])values
                          count:(NSUInteger)count;
 
 /**
@@ -1021,7 +1021,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param values The values to add to this array.
  * @param count  The number of elements to add.
  **/
-- (void)addValues:(const double [])values count:(NSUInteger)count;
+- (void)addValues:(const double [_Nullable])values count:(NSUInteger)count;
 
 /**
  * Adds the values from the given array to this array.
@@ -1128,7 +1128,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized LCIMBoolArray with a copy of the values.
  **/
-- (instancetype)initWithValues:(const BOOL [])values
+- (instancetype)initWithValues:(const BOOL [_Nullable])values
                          count:(NSUInteger)count;
 
 /**
@@ -1193,7 +1193,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param values The values to add to this array.
  * @param count  The number of elements to add.
  **/
-- (void)addValues:(const BOOL [])values count:(NSUInteger)count;
+- (void)addValues:(const BOOL [_Nullable])values count:(NSUInteger)count;
 
 /**
  * Adds the values from the given array to this array.
@@ -1325,7 +1325,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly initialized LCIMEnumArray with a copy of the values.
  **/
 - (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                 rawValues:(const int32_t [])values
+                                 rawValues:(const int32_t [_Nullable])values
                                      count:(NSUInteger)count;
 
 /**
@@ -1435,7 +1435,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param values The values to add to this array.
  * @param count  The number of elements to add.
  **/
-- (void)addValues:(const int32_t [])values count:(NSUInteger)count;
+- (void)addValues:(const int32_t [_Nullable])values count:(NSUInteger)count;
 
 
 /**
@@ -1486,7 +1486,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param values Array containing the raw enum values to add to this array.
  * @param count  The number of raw values to add.
  **/
-- (void)addRawValues:(const int32_t [])values count:(NSUInteger)count;
+- (void)addRawValues:(const int32_t [_Nullable])values count:(NSUInteger)count;
 
 /**
  * Inserts a raw enum value at the given index.

--- a/AVOS/AVOSCloudIM/Protobuf/LCIMDictionary.h
+++ b/AVOS/AVOSCloudIM/Protobuf/LCIMDictionary.h
@@ -84,8 +84,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
-                              forKeys:(const uint32_t [])keys
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [_Nullable])values
+                              forKeys:(const uint32_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -117,8 +117,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithUInt32s:(const uint32_t [])values
-                        forKeys:(const uint32_t [])keys
+- (instancetype)initWithUInt32s:(const uint32_t [_Nullable])values
+                        forKeys:(const uint32_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -228,8 +228,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithInt32s:(const int32_t [])values
-                             forKeys:(const uint32_t [])keys
++ (instancetype)dictionaryWithInt32s:(const int32_t [_Nullable])values
+                             forKeys:(const uint32_t [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -261,8 +261,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithInt32s:(const int32_t [])values
-                       forKeys:(const uint32_t [])keys
+- (instancetype)initWithInt32s:(const int32_t [_Nullable])values
+                       forKeys:(const uint32_t [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -372,8 +372,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
-                              forKeys:(const uint32_t [])keys
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [_Nullable])values
+                              forKeys:(const uint32_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -405,8 +405,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithUInt64s:(const uint64_t [])values
-                        forKeys:(const uint32_t [])keys
+- (instancetype)initWithUInt64s:(const uint64_t [_Nullable])values
+                        forKeys:(const uint32_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -516,8 +516,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithInt64s:(const int64_t [])values
-                             forKeys:(const uint32_t [])keys
++ (instancetype)dictionaryWithInt64s:(const int64_t [_Nullable])values
+                             forKeys:(const uint32_t [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -549,8 +549,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithInt64s:(const int64_t [])values
-                       forKeys:(const uint32_t [])keys
+- (instancetype)initWithInt64s:(const int64_t [_Nullable])values
+                       forKeys:(const uint32_t [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -660,8 +660,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithBools:(const BOOL [])values
-                            forKeys:(const uint32_t [])keys
++ (instancetype)dictionaryWithBools:(const BOOL [_Nullable])values
+                            forKeys:(const uint32_t [_Nullable])keys
                               count:(NSUInteger)count;
 
 /**
@@ -693,8 +693,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithBools:(const BOOL [])values
-                      forKeys:(const uint32_t [])keys
+- (instancetype)initWithBools:(const BOOL [_Nullable])values
+                      forKeys:(const uint32_t [_Nullable])keys
                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -804,8 +804,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithFloats:(const float [])values
-                             forKeys:(const uint32_t [])keys
++ (instancetype)dictionaryWithFloats:(const float [_Nullable])values
+                             forKeys:(const uint32_t [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -837,8 +837,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithFloats:(const float [])values
-                       forKeys:(const uint32_t [])keys
+- (instancetype)initWithFloats:(const float [_Nullable])values
+                       forKeys:(const uint32_t [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -948,8 +948,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithDoubles:(const double [])values
-                              forKeys:(const uint32_t [])keys
++ (instancetype)dictionaryWithDoubles:(const double [_Nullable])values
+                              forKeys:(const uint32_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -981,8 +981,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithDoubles:(const double [])values
-                        forKeys:(const uint32_t [])keys
+- (instancetype)initWithDoubles:(const double [_Nullable])values
+                        forKeys:(const uint32_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -1107,8 +1107,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly instanced dictionary with the keys and values in it.
  **/
 + (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [])values
-                                         forKeys:(const uint32_t [])keys
+                                       rawValues:(const int32_t [_Nullable])values
+                                         forKeys:(const uint32_t [_Nullable])keys
                                            count:(NSUInteger)count;
 
 /**
@@ -1153,8 +1153,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly initialized dictionary with the keys and values in it.
  **/
 - (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                 rawValues:(const int32_t [])values
-                                   forKeys:(const uint32_t [])keys
+                                 rawValues:(const int32_t [_Nullable])values
+                                   forKeys:(const uint32_t [_Nullable])keys
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -1318,8 +1318,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithObjects:(const ObjectType GPB_UNSAFE_UNRETAINED [])objects
-                              forKeys:(const uint32_t [])keys
++ (instancetype)dictionaryWithObjects:(const ObjectType _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])objects
+                              forKeys:(const uint32_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -1351,8 +1351,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithObjects:(const ObjectType GPB_UNSAFE_UNRETAINED [])objects
-                        forKeys:(const uint32_t [])keys
+- (instancetype)initWithObjects:(const ObjectType _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])objects
+                        forKeys:(const uint32_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -1461,8 +1461,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
-                              forKeys:(const int32_t [])keys
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [_Nullable])values
+                              forKeys:(const int32_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -1494,8 +1494,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithUInt32s:(const uint32_t [])values
-                        forKeys:(const int32_t [])keys
+- (instancetype)initWithUInt32s:(const uint32_t [_Nullable])values
+                        forKeys:(const int32_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -1605,8 +1605,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithInt32s:(const int32_t [])values
-                             forKeys:(const int32_t [])keys
++ (instancetype)dictionaryWithInt32s:(const int32_t [_Nullable])values
+                             forKeys:(const int32_t [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -1638,8 +1638,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithInt32s:(const int32_t [])values
-                       forKeys:(const int32_t [])keys
+- (instancetype)initWithInt32s:(const int32_t [_Nullable])values
+                       forKeys:(const int32_t [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -1749,8 +1749,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
-                              forKeys:(const int32_t [])keys
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [_Nullable])values
+                              forKeys:(const int32_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -1782,8 +1782,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithUInt64s:(const uint64_t [])values
-                        forKeys:(const int32_t [])keys
+- (instancetype)initWithUInt64s:(const uint64_t [_Nullable])values
+                        forKeys:(const int32_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -1893,8 +1893,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithInt64s:(const int64_t [])values
-                             forKeys:(const int32_t [])keys
++ (instancetype)dictionaryWithInt64s:(const int64_t [_Nullable])values
+                             forKeys:(const int32_t [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -1926,8 +1926,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithInt64s:(const int64_t [])values
-                       forKeys:(const int32_t [])keys
+- (instancetype)initWithInt64s:(const int64_t [_Nullable])values
+                       forKeys:(const int32_t [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -2037,8 +2037,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithBools:(const BOOL [])values
-                            forKeys:(const int32_t [])keys
++ (instancetype)dictionaryWithBools:(const BOOL [_Nullable])values
+                            forKeys:(const int32_t [_Nullable])keys
                               count:(NSUInteger)count;
 
 /**
@@ -2070,8 +2070,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithBools:(const BOOL [])values
-                      forKeys:(const int32_t [])keys
+- (instancetype)initWithBools:(const BOOL [_Nullable])values
+                      forKeys:(const int32_t [_Nullable])keys
                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -2181,8 +2181,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithFloats:(const float [])values
-                             forKeys:(const int32_t [])keys
++ (instancetype)dictionaryWithFloats:(const float [_Nullable])values
+                             forKeys:(const int32_t [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -2214,8 +2214,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithFloats:(const float [])values
-                       forKeys:(const int32_t [])keys
+- (instancetype)initWithFloats:(const float [_Nullable])values
+                       forKeys:(const int32_t [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -2325,8 +2325,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithDoubles:(const double [])values
-                              forKeys:(const int32_t [])keys
++ (instancetype)dictionaryWithDoubles:(const double [_Nullable])values
+                              forKeys:(const int32_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -2358,8 +2358,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithDoubles:(const double [])values
-                        forKeys:(const int32_t [])keys
+- (instancetype)initWithDoubles:(const double [_Nullable])values
+                        forKeys:(const int32_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -2484,8 +2484,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly instanced dictionary with the keys and values in it.
  **/
 + (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [])values
-                                         forKeys:(const int32_t [])keys
+                                       rawValues:(const int32_t [_Nullable])values
+                                         forKeys:(const int32_t [_Nullable])keys
                                            count:(NSUInteger)count;
 
 /**
@@ -2530,8 +2530,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly initialized dictionary with the keys and values in it.
  **/
 - (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                 rawValues:(const int32_t [])values
-                                   forKeys:(const int32_t [])keys
+                                 rawValues:(const int32_t [_Nullable])values
+                                   forKeys:(const int32_t [_Nullable])keys
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -2695,8 +2695,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithObjects:(const ObjectType GPB_UNSAFE_UNRETAINED [])objects
-                              forKeys:(const int32_t [])keys
++ (instancetype)dictionaryWithObjects:(const ObjectType _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])objects
+                              forKeys:(const int32_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -2728,8 +2728,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithObjects:(const ObjectType GPB_UNSAFE_UNRETAINED [])objects
-                        forKeys:(const int32_t [])keys
+- (instancetype)initWithObjects:(const ObjectType _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])objects
+                        forKeys:(const int32_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -2838,8 +2838,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
-                              forKeys:(const uint64_t [])keys
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [_Nullable])values
+                              forKeys:(const uint64_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -2871,8 +2871,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithUInt32s:(const uint32_t [])values
-                        forKeys:(const uint64_t [])keys
+- (instancetype)initWithUInt32s:(const uint32_t [_Nullable])values
+                        forKeys:(const uint64_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -2982,8 +2982,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithInt32s:(const int32_t [])values
-                             forKeys:(const uint64_t [])keys
++ (instancetype)dictionaryWithInt32s:(const int32_t [_Nullable])values
+                             forKeys:(const uint64_t [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -3015,8 +3015,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithInt32s:(const int32_t [])values
-                       forKeys:(const uint64_t [])keys
+- (instancetype)initWithInt32s:(const int32_t [_Nullable])values
+                       forKeys:(const uint64_t [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -3126,8 +3126,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
-                              forKeys:(const uint64_t [])keys
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [_Nullable])values
+                              forKeys:(const uint64_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -3159,8 +3159,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithUInt64s:(const uint64_t [])values
-                        forKeys:(const uint64_t [])keys
+- (instancetype)initWithUInt64s:(const uint64_t [_Nullable])values
+                        forKeys:(const uint64_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -3270,8 +3270,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithInt64s:(const int64_t [])values
-                             forKeys:(const uint64_t [])keys
++ (instancetype)dictionaryWithInt64s:(const int64_t [_Nullable])values
+                             forKeys:(const uint64_t [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -3303,8 +3303,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithInt64s:(const int64_t [])values
-                       forKeys:(const uint64_t [])keys
+- (instancetype)initWithInt64s:(const int64_t [_Nullable])values
+                       forKeys:(const uint64_t [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -3414,8 +3414,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithBools:(const BOOL [])values
-                            forKeys:(const uint64_t [])keys
++ (instancetype)dictionaryWithBools:(const BOOL [_Nullable])values
+                            forKeys:(const uint64_t [_Nullable])keys
                               count:(NSUInteger)count;
 
 /**
@@ -3447,8 +3447,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithBools:(const BOOL [])values
-                      forKeys:(const uint64_t [])keys
+- (instancetype)initWithBools:(const BOOL [_Nullable])values
+                      forKeys:(const uint64_t [_Nullable])keys
                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -3558,8 +3558,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithFloats:(const float [])values
-                             forKeys:(const uint64_t [])keys
++ (instancetype)dictionaryWithFloats:(const float [_Nullable])values
+                             forKeys:(const uint64_t [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -3591,8 +3591,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithFloats:(const float [])values
-                       forKeys:(const uint64_t [])keys
+- (instancetype)initWithFloats:(const float [_Nullable])values
+                       forKeys:(const uint64_t [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -3702,8 +3702,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithDoubles:(const double [])values
-                              forKeys:(const uint64_t [])keys
++ (instancetype)dictionaryWithDoubles:(const double [_Nullable])values
+                              forKeys:(const uint64_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -3730,13 +3730,13 @@ NS_ASSUME_NONNULL_BEGIN
  * Initializes this dictionary, copying the given values and keys.
  *
  * @param values      The values to be placed in this dictionary.
- * @param keys        The keys under which to store the values.
+ * @param keys        The keys under which to store the_Nullable values.
  * @param count       The number of elements to copy into the dictionary.
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithDoubles:(const double [])values
-                        forKeys:(const uint64_t [])keys
+- (instancetype)initWithDoubles:(const double [_Nullable])values
+                        forKeys:(const uint64_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -3861,8 +3861,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly instanced dictionary with the keys and values in it.
  **/
 + (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [])values
-                                         forKeys:(const uint64_t [])keys
+                                       rawValues:(const int32_t [_Nullable])values
+                                         forKeys:(const uint64_t [_Nullable])keys
                                            count:(NSUInteger)count;
 
 /**
@@ -3907,8 +3907,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly initialized dictionary with the keys and values in it.
  **/
 - (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                 rawValues:(const int32_t [])values
-                                   forKeys:(const uint64_t [])keys
+                                 rawValues:(const int32_t [_Nullable])values
+                                   forKeys:(const uint64_t [_Nullable])keys
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -4072,8 +4072,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithObjects:(const ObjectType GPB_UNSAFE_UNRETAINED [])objects
-                              forKeys:(const uint64_t [])keys
++ (instancetype)dictionaryWithObjects:(const ObjectType _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])objects
+                              forKeys:(const uint64_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -4105,8 +4105,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithObjects:(const ObjectType GPB_UNSAFE_UNRETAINED [])objects
-                        forKeys:(const uint64_t [])keys
+- (instancetype)initWithObjects:(const ObjectType _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])objects
+                        forKeys:(const uint64_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -4215,8 +4215,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
-                              forKeys:(const int64_t [])keys
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [_Nullable])values
+                              forKeys:(const int64_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -4248,8 +4248,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithUInt32s:(const uint32_t [])values
-                        forKeys:(const int64_t [])keys
+- (instancetype)initWithUInt32s:(const uint32_t [_Nullable])values
+                        forKeys:(const int64_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -4359,8 +4359,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithInt32s:(const int32_t [])values
-                             forKeys:(const int64_t [])keys
++ (instancetype)dictionaryWithInt32s:(const int32_t [_Nullable])values
+                             forKeys:(const int64_t [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -4392,8 +4392,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithInt32s:(const int32_t [])values
-                       forKeys:(const int64_t [])keys
+- (instancetype)initWithInt32s:(const int32_t [_Nullable])values
+                       forKeys:(const int64_t [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -4503,8 +4503,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
-                              forKeys:(const int64_t [])keys
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [_Nullable])values
+                              forKeys:(const int64_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -4536,8 +4536,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithUInt64s:(const uint64_t [])values
-                        forKeys:(const int64_t [])keys
+- (instancetype)initWithUInt64s:(const uint64_t [_Nullable])values
+                        forKeys:(const int64_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -4647,8 +4647,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithInt64s:(const int64_t [])values
-                             forKeys:(const int64_t [])keys
++ (instancetype)dictionaryWithInt64s:(const int64_t [_Nullable])values
+                             forKeys:(const int64_t [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -4680,8 +4680,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithInt64s:(const int64_t [])values
-                       forKeys:(const int64_t [])keys
+- (instancetype)initWithInt64s:(const int64_t [_Nullable])values
+                       forKeys:(const int64_t [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -4791,8 +4791,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithBools:(const BOOL [])values
-                            forKeys:(const int64_t [])keys
++ (instancetype)dictionaryWithBools:(const BOOL [_Nullable])values
+                            forKeys:(const int64_t [_Nullable])keys
                               count:(NSUInteger)count;
 
 /**
@@ -4824,8 +4824,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithBools:(const BOOL [])values
-                      forKeys:(const int64_t [])keys
+- (instancetype)initWithBools:(const BOOL [_Nullable])values
+                      forKeys:(const int64_t [_Nullable])keys
                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -4935,8 +4935,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithFloats:(const float [])values
-                             forKeys:(const int64_t [])keys
++ (instancetype)dictionaryWithFloats:(const float [_Nullable])values
+                             forKeys:(const int64_t [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -4968,8 +4968,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithFloats:(const float [])values
-                       forKeys:(const int64_t [])keys
+- (instancetype)initWithFloats:(const float [_Nullable])values
+                       forKeys:(const int64_t [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -5079,8 +5079,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithDoubles:(const double [])values
-                              forKeys:(const int64_t [])keys
++ (instancetype)dictionaryWithDoubles:(const double [_Nullable])values
+                              forKeys:(const int64_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -5112,8 +5112,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithDoubles:(const double [])values
-                        forKeys:(const int64_t [])keys
+- (instancetype)initWithDoubles:(const double [_Nullable])values
+                        forKeys:(const int64_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -5238,8 +5238,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly instanced dictionary with the keys and values in it.
  **/
 + (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [])values
-                                         forKeys:(const int64_t [])keys
+                                       rawValues:(const int32_t [_Nullable])values
+                                         forKeys:(const int64_t [_Nullable])keys
                                            count:(NSUInteger)count;
 
 /**
@@ -5284,8 +5284,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly initialized dictionary with the keys and values in it.
  **/
 - (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                 rawValues:(const int32_t [])values
-                                   forKeys:(const int64_t [])keys
+                                 rawValues:(const int32_t [_Nullable])values
+                                   forKeys:(const int64_t [_Nullable])keys
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -5449,8 +5449,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithObjects:(const ObjectType GPB_UNSAFE_UNRETAINED [])objects
-                              forKeys:(const int64_t [])keys
++ (instancetype)dictionaryWithObjects:(const ObjectType _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])objects
+                              forKeys:(const int64_t [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -5482,8 +5482,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithObjects:(const ObjectType GPB_UNSAFE_UNRETAINED [])objects
-                        forKeys:(const int64_t [])keys
+- (instancetype)initWithObjects:(const ObjectType _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])objects
+                        forKeys:(const int64_t [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -5592,8 +5592,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
-                              forKeys:(const BOOL [])keys
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [_Nullable])values
+                              forKeys:(const BOOL [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -5625,8 +5625,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithUInt32s:(const uint32_t [])values
-                        forKeys:(const BOOL [])keys
+- (instancetype)initWithUInt32s:(const uint32_t [_Nullable])values
+                        forKeys:(const BOOL [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -5736,8 +5736,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithInt32s:(const int32_t [])values
-                             forKeys:(const BOOL [])keys
++ (instancetype)dictionaryWithInt32s:(const int32_t [_Nullable])values
+                             forKeys:(const BOOL [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -5769,8 +5769,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithInt32s:(const int32_t [])values
-                       forKeys:(const BOOL [])keys
+- (instancetype)initWithInt32s:(const int32_t [_Nullable])values
+                       forKeys:(const BOOL [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -5880,8 +5880,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
-                              forKeys:(const BOOL [])keys
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [_Nullable])values
+                              forKeys:(const BOOL [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -5913,8 +5913,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithUInt64s:(const uint64_t [])values
-                        forKeys:(const BOOL [])keys
+- (instancetype)initWithUInt64s:(const uint64_t [_Nullable])values
+                        forKeys:(const BOOL [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -6024,8 +6024,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithInt64s:(const int64_t [])values
-                             forKeys:(const BOOL [])keys
++ (instancetype)dictionaryWithInt64s:(const int64_t [_Nullable])values
+                             forKeys:(const BOOL [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -6057,8 +6057,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithInt64s:(const int64_t [])values
-                       forKeys:(const BOOL [])keys
+- (instancetype)initWithInt64s:(const int64_t [_Nullable])values
+                       forKeys:(const BOOL [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -6168,8 +6168,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithBools:(const BOOL [])values
-                            forKeys:(const BOOL [])keys
++ (instancetype)dictionaryWithBools:(const BOOL [_Nullable])values
+                            forKeys:(const BOOL [_Nullable])keys
                               count:(NSUInteger)count;
 
 /**
@@ -6201,8 +6201,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithBools:(const BOOL [])values
-                      forKeys:(const BOOL [])keys
+- (instancetype)initWithBools:(const BOOL [_Nullable])values
+                      forKeys:(const BOOL [_Nullable])keys
                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -6312,8 +6312,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithFloats:(const float [])values
-                             forKeys:(const BOOL [])keys
++ (instancetype)dictionaryWithFloats:(const float [_Nullable])values
+                             forKeys:(const BOOL [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -6345,8 +6345,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithFloats:(const float [])values
-                       forKeys:(const BOOL [])keys
+- (instancetype)initWithFloats:(const float [_Nullable])values
+                       forKeys:(const BOOL [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -6456,8 +6456,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithDoubles:(const double [])values
-                              forKeys:(const BOOL [])keys
++ (instancetype)dictionaryWithDoubles:(const double [_Nullable])values
+                              forKeys:(const BOOL [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -6489,8 +6489,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithDoubles:(const double [])values
-                        forKeys:(const BOOL [])keys
+- (instancetype)initWithDoubles:(const double [_Nullable])values
+                        forKeys:(const BOOL [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -6615,8 +6615,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly instanced dictionary with the keys and values in it.
  **/
 + (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [])values
-                                         forKeys:(const BOOL [])keys
+                                       rawValues:(const int32_t [_Nullable])values
+                                         forKeys:(const BOOL [_Nullable])keys
                                            count:(NSUInteger)count;
 
 /**
@@ -6661,8 +6661,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly initialized dictionary with the keys and values in it.
  **/
 - (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                 rawValues:(const int32_t [])values
-                                   forKeys:(const BOOL [])keys
+                                 rawValues:(const int32_t [_Nullable])values
+                                   forKeys:(const BOOL [_Nullable])keys
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -6826,8 +6826,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithObjects:(const ObjectType GPB_UNSAFE_UNRETAINED [])objects
-                              forKeys:(const BOOL [])keys
++ (instancetype)dictionaryWithObjects:(const ObjectType _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])objects
+                              forKeys:(const BOOL [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -6859,8 +6859,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithObjects:(const ObjectType GPB_UNSAFE_UNRETAINED [])objects
-                        forKeys:(const BOOL [])keys
+- (instancetype)initWithObjects:(const ObjectType _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])objects
+                        forKeys:(const BOOL [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -6969,8 +6969,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithUInt32s:(const uint32_t [])values
-                              forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
++ (instancetype)dictionaryWithUInt32s:(const uint32_t [_Nullable])values
+                              forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -7002,8 +7002,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithUInt32s:(const uint32_t [])values
-                        forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+- (instancetype)initWithUInt32s:(const uint32_t [_Nullable])values
+                        forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -7113,8 +7113,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithInt32s:(const int32_t [])values
-                             forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
++ (instancetype)dictionaryWithInt32s:(const int32_t [_Nullable])values
+                             forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -7146,8 +7146,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithInt32s:(const int32_t [])values
-                       forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+- (instancetype)initWithInt32s:(const int32_t [_Nullable])values
+                       forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -7257,8 +7257,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithUInt64s:(const uint64_t [])values
-                              forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
++ (instancetype)dictionaryWithUInt64s:(const uint64_t [_Nullable])values
+                              forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -7290,8 +7290,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithUInt64s:(const uint64_t [])values
-                        forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+- (instancetype)initWithUInt64s:(const uint64_t [_Nullable])values
+                        forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -7401,8 +7401,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithInt64s:(const int64_t [])values
-                             forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
++ (instancetype)dictionaryWithInt64s:(const int64_t [_Nullable])values
+                             forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -7434,8 +7434,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithInt64s:(const int64_t [])values
-                       forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+- (instancetype)initWithInt64s:(const int64_t [_Nullable])values
+                       forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -7545,8 +7545,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithBools:(const BOOL [])values
-                            forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
++ (instancetype)dictionaryWithBools:(const BOOL [_Nullable])values
+                            forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                               count:(NSUInteger)count;
 
 /**
@@ -7578,8 +7578,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithBools:(const BOOL [])values
-                      forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+- (instancetype)initWithBools:(const BOOL [_Nullable])values
+                      forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                         count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -7689,8 +7689,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithFloats:(const float [])values
-                             forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
++ (instancetype)dictionaryWithFloats:(const float [_Nullable])values
+                             forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                                count:(NSUInteger)count;
 
 /**
@@ -7722,8 +7722,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithFloats:(const float [])values
-                       forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+- (instancetype)initWithFloats:(const float [_Nullable])values
+                       forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                          count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -7833,8 +7833,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly instanced dictionary with the keys and values in it.
  **/
-+ (instancetype)dictionaryWithDoubles:(const double [])values
-                              forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
++ (instancetype)dictionaryWithDoubles:(const double [_Nullable])values
+                              forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                                 count:(NSUInteger)count;
 
 /**
@@ -7866,8 +7866,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A newly initialized dictionary with a copy of the values and keys.
  **/
-- (instancetype)initWithDoubles:(const double [])values
-                        forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+- (instancetype)initWithDoubles:(const double [_Nullable])values
+                        forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                           count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**
@@ -7992,8 +7992,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly instanced dictionary with the keys and values in it.
  **/
 + (instancetype)dictionaryWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                       rawValues:(const int32_t [])values
-                                         forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+                                       rawValues:(const int32_t [_Nullable])values
+                                         forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                                            count:(NSUInteger)count;
 
 /**
@@ -8038,8 +8038,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A newly initialized dictionary with the keys and values in it.
  **/
 - (instancetype)initWithValidationFunction:(nullable GPBEnumValidationFunc)func
-                                 rawValues:(const int32_t [])values
-                                   forKeys:(const NSString * GPB_UNSAFE_UNRETAINED [])keys
+                                 rawValues:(const int32_t [_Nullable])values
+                                   forKeys:(const NSString * _Nonnull GPB_UNSAFE_UNRETAINED [_Nullable])keys
                                      count:(NSUInteger)count NS_DESIGNATED_INITIALIZER;
 
 /**

--- a/AVOS/AVOSCloudIM/Protobuf/LCIMDictionary.m
+++ b/AVOS/AVOSCloudIM/Protobuf/LCIMDictionary.m
@@ -7887,7 +7887,11 @@ void LCIMDictionaryReadEntry(id mapDictionary,
 + (instancetype)dictionaryWithDictionary:(LCIMInt64UInt64Dictionary *)dictionary {
   // Cast is needed so the compiler knows what class we are invoking initWithDictionary:
   // on to get the type correct.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
+  // this warning may be a bug of Xcode or clang.
   return [[(LCIMInt64UInt64Dictionary*)[self alloc] initWithDictionary:dictionary] autorelease];
+#pragma clang diagnostic pop
 }
 
 + (instancetype)dictionaryWithCapacity:(NSUInteger)numItems {
@@ -7937,7 +7941,11 @@ void LCIMDictionaryReadEntry(id mapDictionary,
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
+  // this warning may be a bug of Xcode or clang.
   return [[LCIMInt64UInt64Dictionary allocWithZone:zone] initWithDictionary:self];
+#pragma clang diagnostic pop
 }
 
 - (BOOL)isEqual:(id)other {

--- a/AVOS/AVOSCloudIM/Vendor/SocketRocket/AVIMWebSocket.m
+++ b/AVOS/AVOSCloudIM/Vendor/SocketRocket/AVIMWebSocket.m
@@ -499,7 +499,11 @@ static __strong NSData *CRLFCRLF;
     CFHTTPMessageSetHeaderFieldValue(request, CFSTR("Host"), (__bridge CFStringRef)(_url.port ? [NSString stringWithFormat:@"%@:%@", _url.host, _url.port] : _url.host));
         
     NSMutableData *keyBytes = [[NSMutableData alloc] initWithLength:16];
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-result"
     SecRandomCopyBytes(kSecRandomDefault, keyBytes.length, keyBytes.mutableBytes);
+#pragma clang diagnostic pop
     
     if ([keyBytes respondsToSelector:@selector(base64EncodedStringWithOptions:)]) {
         _secKey = [keyBytes base64EncodedStringWithOptions:0];
@@ -1391,7 +1395,12 @@ static const size_t AVIMFrameHeaderOverhead = 32;
         }
     } else {
         uint8_t *mask_key = frame_buffer + frame_buffer_size;
+        
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-result"
         SecRandomCopyBytes(kSecRandomDefault, sizeof(uint32_t), (uint8_t *)mask_key);
+#pragma clang diagnostic pop
+
         frame_buffer_size += sizeof(uint32_t);
         
         // TODO: could probably optimize this with SIMD

--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -478,16 +478,19 @@ SecCertificateRef LCGetCertificateFromBase64String(NSString *base64);
     NSMutableSet *protocols = [NSMutableSet set];
     NSDictionary *userOptions = [AVIMClient userOptions];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if ([userOptions[AVIMUserOptionUseUnread] boolValue]) {
         [protocols addObject:AVIMProtocolPROTOBUF3];
     } else {
         [protocols addObject:AVIMProtocolPROTOBUF1];
     }
-
+    
     if (userOptions[AVIMUserOptionCustomProtocols]) {
         [protocols removeAllObjects];
         [protocols addObjectsFromArray:userOptions[AVIMUserOptionCustomProtocols]];
     }
+#pragma clang diagnostic pop
     
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:server]];
 

--- a/AVOS/AVOSCloudLiveQuery/AVSubscriber.m
+++ b/AVOS/AVOSCloudLiveQuery/AVSubscriber.m
@@ -101,9 +101,11 @@ NSNotificationName AVLiveQueryEventNotification = @"AVLiveQueryEventNotification
         return;
 
     switch (command.cmd) {
-    case AVIMCommandType_Data:
-        [self handleDataCommand:command];
-        break;
+        case AVIMCommandType_Data:
+            [self handleDataCommand:command];
+            break;
+        default:
+            break;
     }
 }
 
@@ -128,7 +130,7 @@ NSNotificationName AVLiveQueryEventNotification = @"AVLiveQueryEventNotification
     if (error || !dictionary)
         return;
 
-    NSDictionary *event = [AVObjectUtils objectFromDictionary:dictionary recursive:YES];
+    NSDictionary *event = (NSDictionary *)[AVObjectUtils objectFromDictionary:dictionary recursive:YES];
     NSDictionary *userInfo = @{ AVLiveQueryEventKey: event };
 
     [[NSNotificationCenter defaultCenter] postNotificationName:AVLiveQueryEventNotification

--- a/AVOS/AVOSCloudTests/LogicTests/AVCustomUser.h
+++ b/AVOS/AVOSCloudTests/LogicTests/AVCustomUser.h
@@ -6,7 +6,8 @@
 //  Copyright © 2015年 LeanCloud Inc. All rights reserved.
 //
 
-#import <AVOSCloud/AVOSCloud.h>
+#import "AVOSCloud.h"
+#import "AVSubclassing.h"
 
 @interface AVCustomUser : AVUser<AVSubclassing>
 

--- a/AVOS/AVOSCloudTests/LogicTests/UserArmor.h
+++ b/AVOS/AVOSCloudTests/LogicTests/UserArmor.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013年 AVOS. All rights reserved.
 //
 
-#import <AVOSCloud/AVOSCloud.h>
+#import "AVOSCloud.h"
 #import "AVSubclassing.h"
 #import "UserInfo.h"
 #import "Armor.h"

--- a/AVOS/AVOSCloudTests/LogicTests/UserBar.h
+++ b/AVOS/AVOSCloudTests/LogicTests/UserBar.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import <AVOSCloud/AVOSCloud.h>
+#import "AVOSCloud.h"
 #import "AVSubclassing.h"
 
 @interface UserBar : AVUser<AVSubclassing>

--- a/AVOS/AVOSCloudTests/LogicTests/UserInfo.h
+++ b/AVOS/AVOSCloudTests/LogicTests/UserInfo.h
@@ -7,8 +7,7 @@
 //
 
 
-#import "AVSubclassing.h"
-#import <AVOSCloud/AVOSCloud.h>
+#import "AVOSCloud.h"
 #import "AVSubclassing.h"
 
 

--- a/AVOS/Resources/AVOSCloud-iOSTests.Info.plist
+++ b/AVOS/Resources/AVOSCloud-iOSTests.Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>cn.leancloud.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/AVOS/Resources/AVOSCloud-tvOS.Info.plist
+++ b/AVOS/Resources/AVOSCloud-tvOS.Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.avoscloud.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/AVOS/Resources/AVOSCloud-watchOS.Info.plist
+++ b/AVOS/Resources/AVOSCloud-watchOS.Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.avoscloud.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/AVOS/Resources/AVOSCloudCrashReporting-iOS.Info.plist
+++ b/AVOS/Resources/AVOSCloudCrashReporting-iOS.Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.avoscloud.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/AVOS/Resources/AVOSCloudIM-iOS.Info.plist
+++ b/AVOS/Resources/AVOSCloudIM-iOS.Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.avoscloud.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/AVOS/Resources/AVOSCloudIM-iOSTests.Info.plist
+++ b/AVOS/Resources/AVOSCloudIM-iOSTests.Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>cn.leancloud.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
* 修复大量在 Xcode 9 编译过程中产生的⚠️

* `AVErrorUtils` 在 JSON 数据里递归的查找 error 时，没有对 value 进行类型判断，所以出现了把 `NSDictionary *` 强制判定为 `NSString *` 类型的情况，导致 **unrecognized selector sent to instance** 的 crash 。

@leancloud/ios-group