### PR TITLE
set log info default is no

### DIFF
--- a/AVOS/AVOSCloud/AVOSCloud.h
+++ b/AVOS/AVOSCloud/AVOSCloud.h
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AVOSCloud : NSObject
 
 /*!
- * Enable logs of all levels and domains. When define DEBUG macro, it's enabled, otherwise, it's not enabled. This is recommended. But you can set it NO, and call AVLogger's methods to control which domains' log should be output.
+ * Enable logs of all levels and domains. When define DEBUG macro, it's enabled, otherwise, it's not enabled. This is recommended. But you can set it NO, and call AVLogger's methods to control which domains' log should be output. Default is NO.
  */
 + (void)setAllLogsEnabled:(BOOL)enabled;
 

--- a/AVOS/AVOSCloud/AVOSCloud.m
+++ b/AVOS/AVOSCloud/AVOSCloud.m
@@ -98,6 +98,7 @@ AVServiceRegion LCEffectiveServiceRegion = AVServiceRegionDefault;
 
     [self initializePaasClient];
     [self updateRouterInBackground];
+    [self setAllLogsEnabled: NO];
     [[LCNetworkStatistics sharedInstance] start];
 
     for (Class<AVOSCloudModule> cls in AVOSCloudModules) {


### PR DESCRIPTION
默认是打开的，对于开发者而言是否不太好，如果没注意，可能会直接打包。

应该是开发者需要时候，去打开。
而不是开发者不需要时候，去关闭。