### PR TITLE
Support to read user-defined property from message

### DIFF
--- a/AVOS/AVOSCloudIM/TypedMessages/AVIMTypedMessage.h
+++ b/AVOS/AVOSCloudIM/TypedMessages/AVIMTypedMessage.h
@@ -41,6 +41,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setObject:(nullable id)object forKey:(NSString *)key;
 
 /**
+ Get a user-defiend property for a key.
+
+ @param key The key of property that you want to get.
+ @return The value for key.
+ */
+- (nullable id)objectForKey:(NSString *)key;
+
+/**
  *  子类调用此方法进行注册，一般可在子类的 [+(void)load] 方法里面调用
  */
 + (void)registerSubclass;

--- a/AVOS/AVOSCloudIM/TypedMessages/AVIMTypedMessage.m
+++ b/AVOS/AVOSCloudIM/TypedMessages/AVIMTypedMessage.m
@@ -260,6 +260,10 @@ NSMutableDictionary const *_typeDict = nil;
     [self.messageObject setObject:object forKey:key];
 }
 
+- (id)objectForKey:(NSString *)key {
+    return [self.messageObject objectForKey:key];
+}
+
 - (NSString *)payload {
     NSDictionary *dict = [self.messageObject dictionary];
 


### PR DESCRIPTION
增加方法以支持从 message 中读取用户自定义的属性，之前用户自定义属性是 write-only 的。

@leancloud/ios-group 