### PR TITLE
Rebuild unique index for message table if needed

### DIFF
--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMCacheStore.m
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMCacheStore.m
@@ -60,7 +60,6 @@
         db.logsErrors = LCIM_SHOULD_LOG_ERRORS;
 
         [db executeUpdate:LCIM_SQL_CREATE_MESSAGE_TABLE];
-        [db executeUpdate:LCIM_SQL_CREATE_MESSAGE_UNIQUE_INDEX];
 
         [db executeUpdate:LCIM_SQL_CREATE_CONVERSATION_TABLE];
     }));
@@ -88,6 +87,17 @@
 
         [LCDatabaseMigration migrationWithBlock:^(LCDatabase *db) {
             [db executeStatements:LCIM_SQL_MESSAGE_MIGRATION_V4];
+        }],
+
+        [LCDatabaseMigration migrationWithBlock:^(LCDatabase *db) {
+            LCResultSet *resultSet = [db executeQuery:LCIM_SQL_MESSAGE_UNIQUE_INDEX_INFO];
+            BOOL hasIndex = [resultSet next];
+
+            if (!hasIndex) {
+                [db executeStatements:LCIM_SQL_REBUILD_MESSAGE_UNIQUE_INDEX];
+            }
+
+            [resultSet close];
         }]
     ]];
 }

--- a/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStoreSQL.h
+++ b/AVOS/AVOSCloudIM/MessageCache/CacheStore/LCIMMessageCacheStoreSQL.h
@@ -54,9 +54,6 @@
 #define LCIM_SQL_DELETE_ALL_MESSAGES_OF_CONVERSATION \
 @"delete from message where conversation_id = ?"
 
-#define LCIM_SQL_CREATE_MESSAGE_UNIQUE_INDEX \
-@"create unique index if not exists unique_index on message(conversation_id, message_id, timestamp)"
-
 #define LCIM_SQL_LATEST_MESSAGE \
 @"select * from message where conversation_id = ? order by timestamp desc limit ?"
 
@@ -100,9 +97,7 @@ create index if not exists message_index_conversation_id on message_seq(conversa
 create index if not exists message_index_message_id on message_seq(message_id);                                  \
 create index if not exists message_index_timestamp on message_seq(timestamp);                                    \
                                                                                                                  \
-drop index if exists unique_index;                                                                               \
-                                                                                                                 \
-insert into message_seq(                                                                                         \
+insert or replace into message_seq(                                                                              \
     message_id, conversation_id, from_peer_id, payload, timestamp,                                               \
     receipt_timestamp, read_timestamp, patch_timestamp, status, breakpoint)                                      \
 select                                                                                                           \
@@ -112,6 +107,13 @@ from message order by timestamp asc, message_id asc;                            
                                                                                                                  \
 drop table if exists message;                                                                                    \
 alter table message_seq rename to message;"
+
+#define LCIM_SQL_MESSAGE_UNIQUE_INDEX_INFO \
+@"pragma index_info(message_unique_index)"
+
+#define LCIM_SQL_REBUILD_MESSAGE_UNIQUE_INDEX \
+@"delete from message;"               \
+@"create unique index if not exists message_unique_index on message(conversation_id, message_id, timestamp);"
 
 #define LCIM_SQL_LAST_MESSAGE_SEQ \
 @"select seq from sqlite_sequence where name=\"message\""


### PR DESCRIPTION
用户反馈消息历史查询会出现重复数据。分析 db 后发现 message 表的唯一索引丢失，丢失原因尚不明确。这里增加了一个 migration，如果发现唯一索引丢失，删除表中所有数据后重建索引。

@leancloud/ios-group @nicecui 