### PR TITLE
Rework part of 'AVIMClient'

### DIFF
--- a/AVOS/AVOS.xcodeproj/project.pbxproj
+++ b/AVOS/AVOS.xcodeproj/project.pbxproj
@@ -1206,6 +1206,8 @@
 		D37A046B1FF3705500AD44A9 /* testFile.md in Resources */ = {isa = PBXBuildFile; fileRef = D37A04691FF3705500AD44A9 /* testFile.md */; };
 		D37CD4111FF0EB9100187AC1 /* LCIMTestCaseQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37CD4101FF0EB9100187AC1 /* LCIMTestCaseQuery.swift */; };
 		D37CD4121FF0EB9100187AC1 /* LCIMTestCaseQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37CD4101FF0EB9100187AC1 /* LCIMTestCaseQuery.swift */; };
+		D3917130200DE4290061CCF4 /* AVErrorUtilsTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D391712F200DE4290061CCF4 /* AVErrorUtilsTestCase.swift */; };
+		D3917131200DE4290061CCF4 /* AVErrorUtilsTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D391712F200DE4290061CCF4 /* AVErrorUtilsTestCase.swift */; };
 		D3CDF4EB1FE8F3810033153E /* LCIMTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3CDF4EA1FE8F3810033153E /* LCIMTestBase.swift */; };
 		D3CDF4EC1FE8F3810033153E /* LCIMTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3CDF4EA1FE8F3810033153E /* LCIMTestBase.swift */; };
 		D3CDF4F01FE8F5830033153E /* LCIMTestCaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3CDF4EF1FE8F5830033153E /* LCIMTestCaseClient.swift */; };
@@ -1739,6 +1741,7 @@
 		D37A04661FF36E6200AD44A9 /* testVideo.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = testVideo.mp4; sourceTree = "<group>"; };
 		D37A04691FF3705500AD44A9 /* testFile.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = testFile.md; sourceTree = "<group>"; };
 		D37CD4101FF0EB9100187AC1 /* LCIMTestCaseQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCIMTestCaseQuery.swift; sourceTree = "<group>"; };
+		D391712F200DE4290061CCF4 /* AVErrorUtilsTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVErrorUtilsTestCase.swift; sourceTree = "<group>"; };
 		D3CDF4EA1FE8F3810033153E /* LCIMTestBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCIMTestBase.swift; sourceTree = "<group>"; };
 		D3CDF4EF1FE8F5830033153E /* LCIMTestCaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCIMTestCaseClient.swift; sourceTree = "<group>"; };
 		D3DA60C81FF5E42D00AC5F4F /* AVOSCloudLiveQuery.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = AVOSCloudLiveQuery.podspec; path = ../AVOSCloudLiveQuery.podspec; sourceTree = "<group>"; };
@@ -2760,6 +2763,7 @@
 			children = (
 				D30DF3F61FDE2CD200F932BC /* AVUserTestCase.swift */,
 				D36AC7681FFF50AB00BDCA24 /* AVInstallationTestCase.swift */,
+				D391712F200DE4290061CCF4 /* AVErrorUtilsTestCase.swift */,
 			);
 			path = Swift;
 			sourceTree = "<group>";
@@ -4212,6 +4216,7 @@
 				70AF993D1BE1D0FA0091F46F /* AVCustomUser.m in Sources */,
 				D30DF3F81FDE2CD200F932BC /* AVUserTestCase.swift in Sources */,
 				70F3154F1BDE510D00D691B3 /* Armor.m in Sources */,
+				D3917131200DE4290061CCF4 /* AVErrorUtilsTestCase.swift in Sources */,
 				705A389B1BDF606600864B72 /* AVPersistentUtilsTest.m in Sources */,
 				70F315501BDE510D00D691B3 /* Thread.m in Sources */,
 				70F315511BDE510D00D691B3 /* UserArmor.m in Sources */,
@@ -4538,6 +4543,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D3917130200DE4290061CCF4 /* AVErrorUtilsTestCase.swift in Sources */,
 				8CEEABD31ABC179300B9E757 /* AVRelationTest.m in Sources */,
 				D30DF3F71FDE2CD200F932BC /* AVUserTestCase.swift in Sources */,
 				705A389A1BDF605C00864B72 /* AVPersistentUtilsTest.m in Sources */,

--- a/AVOS/AVOSCloud/AVOSCloud.h
+++ b/AVOS/AVOSCloud/AVOSCloud.h
@@ -114,9 +114,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AVOSCloud : NSObject
 
 /**
- Enable SSL Pinning for all HTTPS Requests.
- Default is True.
-
+ A switch of SSL Pinning for all LeanCloud's HTTPS Requests.
+ Default is False.
+ 
  @param enabled Set whatever you want if you master SSL & SSL Pinning.
  */
 + (void)setSSLPinningEnabled:(BOOL)enabled;

--- a/AVOS/AVOSCloud/AVOSCloud.m
+++ b/AVOS/AVOSCloud/AVOSCloud.m
@@ -34,7 +34,7 @@ static BOOL LCInitialized = NO;
 
 AVServiceRegion LCEffectiveServiceRegion = AVServiceRegionDefault;
 
-static BOOL LCSSLPinningEnabled = true;
+static BOOL LCSSLPinningEnabled = false;
 
 @implementation AVOSCloud
 

--- a/AVOS/AVOSCloud/Utils/AVErrorUtils.h
+++ b/AVOS/AVOSCloud/Utils/AVErrorUtils.h
@@ -12,21 +12,27 @@ extern NSString * const kAVErrorDomain;
 extern NSString * const kAVErrorUnknownText;
 
 typedef NS_ENUM(NSInteger, AVLocalErrorCode) {
-    AVLocalErrorCodeInvalidArgument = 10000
+    
+    AVLocalErrorCodeInvalidArgument = -10000
 };
 
 @interface AVErrorUtils : NSObject
 
-+(NSError *)errorWithCode:(NSInteger)code;
-+(NSError *)errorWithCode:(NSInteger)code errorText:(NSString *)text;
++ (NSError *)errorWithCode:(NSInteger)code;
+
++ (NSError *)errorWithCode:(NSInteger)code
+                 errorText:(NSString *)text;
+
 + (NSError *)errorWithText:(NSString *)text;
 
-+(NSError *)internalServerError;
-+(NSError *)fileNotFoundError;
-+(NSError *)dataNotAvailableError;
++ (NSError *)internalServerError;
+
++ (NSError *)fileNotFoundError;
+
++ (NSError *)dataNotAvailableError;
 
 + (NSError *)errorFromJSON:(id)JSON;
-+ (NSString *)errorTextFromError:(NSError *)error;
+
 + (NSError *)errorFromAVError:(NSError *)error;
 
 @end

--- a/AVOS/AVOSCloudIM/AVIMClient.h
+++ b/AVOS/AVOSCloudIM/AVIMClient.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSUInteger, AVIMClientStatus) {
     
-    /// Initial client status.
+    /// Initial client status or an unknown status.
     AVIMClientStatusNone,
     
     /// Indicate the client is connecting the server now.
@@ -48,6 +48,10 @@ typedef NS_ENUM(NSUInteger, AVIMClientStatus) {
 };
 
 typedef NS_OPTIONS(uint64_t, LCIMClientOpenOption) {
+    
+    /*
+     Use this option when open client means the open action is a reopen or reconnect action.
+     */
     LCIMClientOpenOptionReopen = 1 << 0,
 };
 
@@ -101,8 +105,18 @@ typedef NS_OPTIONS(uint64_t, AVIMConversationOption) {
  */
 @property (nonatomic, assign) BOOL messageQueryCacheEnabled;
 
+/**
+ Unavailable.
+ 
+ @return Exception.
+ */
 + (instancetype)new NS_UNAVAILABLE;
 
+/**
+ Unavailable.
+ 
+ @return Exception.
+ */
 - (instancetype)init NS_UNAVAILABLE;
 
 /*!
@@ -161,6 +175,12 @@ typedef NS_OPTIONS(uint64_t, AVIMConversationOption) {
  */
 - (void)openWithCallback:(AVIMBooleanResultBlock)callback;
 
+/**
+ Open Client with a Option.
+
+ @param openOption Option `LCIMClientOpenOption`.
+ @param callback Result Callback.
+ */
 - (void)openWithOpenOption:(LCIMClientOpenOption)openOption
                   callback:(AVIMBooleanResultBlock)callback;
 
@@ -297,18 +317,18 @@ __attribute__((warn_unused_result));
 @protocol AVIMClientDelegate <NSObject>
 
 /**
- *  当前聊天状态被暂停，常见于网络断开时触发。
+ *  当前聊天状态被暂停，常见于网络断开或应用进入后台之后时触发，网络恢复或应用进入前台后，会自动重连。
  *  @param imClient 相应的 imClient
  */
 - (void)imClientPaused:(AVIMClient *)imClient;
 
 /**
- *  当前聊天状态被暂停，常见于网络断开时触发。
- *  注意：该回调会覆盖 imClientPaused: 方法。
- *  @param imClient 相应的 imClient
- *  @param error    具体错误信息
+ 当前聊天被关闭且不会自动重连时触发。
+
+ @param imClient 相应的 imClient
+ @param error    相应的错误信息
  */
-- (void)imClientPaused:(AVIMClient *)imClient error:(NSError *)error;
+- (void)imClientClosed:(AVIMClient *)imClient error:(NSError *)error;
 
 /**
  *  当前聊天状态开始恢复，常见于网络断开后开始重新连接。
@@ -392,6 +412,15 @@ __attribute__((warn_unused_result));
  */
 - (void)client:(AVIMClient *)client didOfflineWithError:(NSError *)error;
 
+/**
+ *  当前聊天状态被暂停，常见于网络断开时触发。
+ *  注意：该回调会覆盖 imClientPaused: 方法。
+ *  @param imClient 相应的 imClient
+ *  @param error    具体错误信息
+ */
+- (void)imClientPaused:(AVIMClient *)imClient error:(NSError *)error
+__deprecated_msg("Deprecated after v8.2.0 , use -[imClientClosed:error:] instead.");
+
 /*!
  收到未读通知。在该终端上线的时候，服务器会将对话的未读数发送过来。未读数可通过 -[AVIMConversation markAsReadInBackground] 清零，服务端不会自动清零。
  @param conversation 所属会话。
@@ -418,8 +447,9 @@ AVIM_DEPRECATED("Deprecated in v5.1.0. Do not use it any more.");
  * @param callback Callback for openning client.
  * @brief Open client with option of which the properties will override client's default option.
  */
-- (void)openWithOption:(nullable AVIMClientOpenOption *)option callback:(AVIMBooleanResultBlock)callback
-__deprecated_msg("Deprecated in v8.3.0 , use -[openWithOpenOption:callback:] instead.");
+- (void)openWithOption:(nullable AVIMClientOpenOption *)option
+              callback:(AVIMBooleanResultBlock)callback
+__deprecated_msg("Deprecated after v8.2.0 , use -[openWithOpenOption:callback:] instead.");
 
 @end
 

--- a/AVOS/AVOSCloudIM/AVIMClient.h
+++ b/AVOS/AVOSCloudIM/AVIMClient.h
@@ -24,20 +24,31 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSUInteger, AVIMClientStatus) {
+    
     /// Initial client status.
     AVIMClientStatusNone,
+    
     /// Indicate the client is connecting the server now.
     AVIMClientStatusOpening,
+    
     /// Indicate the client connected the server.
     AVIMClientStatusOpened,
+    
     /// Indicate the connection paused. Usually for the network reason.
     AVIMClientStatusPaused,
+    
     /// Indicate the connection is recovering.
     AVIMClientStatusResuming,
+    
     /// Indicate the connection is closing.
     AVIMClientStatusClosing,
+    
     /// Indicate the connection is closed.
     AVIMClientStatusClosed
+};
+
+typedef NS_OPTIONS(uint64_t, LCIMClientOpenOption) {
+    LCIMClientOpenOptionReopen = 1 << 0,
 };
 
 typedef NS_OPTIONS(uint64_t, AVIMConversationOption) {
@@ -66,7 +77,7 @@ typedef NS_OPTIONS(uint64_t, AVIMConversationOption) {
 /**
  *  The ID of the current client. Usually the user's ID.
  */
-@property (nonatomic, copy, readonly, nullable) NSString *clientId;
+@property (nonatomic, strong, readonly, nonnull) NSString *clientId;
 
 /**
  The user that you login as a client.
@@ -78,17 +89,21 @@ typedef NS_OPTIONS(uint64_t, AVIMConversationOption) {
  * @brief If tag is not nil and "default", offline mechanism is enabled.
  * @discussion If one client id login on two different devices, previous opened client will be gone offline by later opened client.
  */
-@property (nonatomic, copy, readonly, nullable) NSString *tag;
+@property (nonatomic, strong, readonly, nullable) NSString *tag;
 
 /**
  *  The connecting status of the current client.
  */
-@property (nonatomic, readonly, assign) AVIMClientStatus status;
+@property (nonatomic, assign, readonly) AVIMClientStatus status;
 
 /**
  * 控制是否打开历史消息查询的本地缓存功能,默认开启
  */
 @property (nonatomic, assign) BOOL messageQueryCacheEnabled;
+
++ (instancetype)new NS_UNAVAILABLE;
+
+- (instancetype)init NS_UNAVAILABLE;
 
 /*!
  Initializes a newly allocated client.
@@ -146,13 +161,8 @@ typedef NS_OPTIONS(uint64_t, AVIMConversationOption) {
  */
 - (void)openWithCallback:(AVIMBooleanResultBlock)callback;
 
-/*!
- * Open client with option.
- * @param option   Option to open client.
- * @param callback Callback for openning client.
- * @brief Open client with option of which the properties will override client's default option.
- */
-- (void)openWithOption:(nullable AVIMClientOpenOption *)option callback:(AVIMBooleanResultBlock)callback;
+- (void)openWithOpenOption:(LCIMClientOpenOption)openOption
+                  callback:(AVIMBooleanResultBlock)callback;
 
 /*!
  结束某个账户的聊天
@@ -285,7 +295,6 @@ __attribute__((warn_unused_result));
  *  The AVIMClientDelegate protocol defines methods to handle these events: connecting status changes, message comes and members of the conversation changes.
  */
 @protocol AVIMClientDelegate <NSObject>
-@optional
 
 /**
  *  当前聊天状态被暂停，常见于网络断开时触发。
@@ -312,6 +321,8 @@ __attribute__((warn_unused_result));
  *  @param imClient 相应的 imClient
  */
 - (void)imClientResumed:(AVIMClient *)imClient;
+
+@optional
 
 /*!
  接收到新的普通消息。
@@ -400,6 +411,15 @@ AVIM_DEPRECATED("Deprecated in AVOSCloudIM SDK 4.3.0. Instead, use `-[AVIMClient
  */
 + (void)setUserOptions:(NSDictionary *)userOptions
 AVIM_DEPRECATED("Deprecated in v5.1.0. Do not use it any more.");
+
+/*!
+ * Open client with option.
+ * @param option   Option to open client.
+ * @param callback Callback for openning client.
+ * @brief Open client with option of which the properties will override client's default option.
+ */
+- (void)openWithOption:(nullable AVIMClientOpenOption *)option callback:(AVIMBooleanResultBlock)callback
+__deprecated_msg("Deprecated in v8.3.0 , use -[openWithOpenOption:callback:] instead.");
 
 @end
 

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -2650,6 +2650,18 @@ __attribute__((warn_unused_result))
     });
 }
 
+// MARK: - Thread Unsafe
+
+- (AVIMClientStatus)threadUnsafe_status
+{
+    return _status;
+}
+
+- (id<AVIMClientDelegate>)threadUnsafe_delegate
+{
+    return _delegate;
+}
+
 // MARK: - Deprecated
 
 + (void)setUserOptions:(NSDictionary *)userOptions {

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -707,11 +707,21 @@ static BOOL AVIMClientHasInstantiated = NO;
         AVIMSessionCommand *sessionCommand = [[AVIMSessionCommand alloc] init];
         [genericCommand avim_addRequiredKeyWithCommand:sessionCommand];
         [genericCommand setCallback:^(AVIMGenericCommand *outCommand, AVIMGenericCommand *inCommand, NSError *error) {
-            if (!error) {
-                [self.socketWrapper close];
-                [self processClientStatusAfterWebSocketOffline];
-            }
-            [AVIMBlockHelper callBooleanResultBlock:callback error:error];
+            
+            dispatch_async(imClientQueue, ^{
+                
+                if (!error) {
+                    
+                    self.openCommand = nil;
+                    
+                    [self.socketWrapper close];
+                    
+                    [self processClientStatusAfterWebSocketOffline];
+                }
+                
+                [AVIMBlockHelper callBooleanResultBlock:callback
+                                                  error:error];
+            });
         }];
         [self sendCommand:genericCommand withBeforeSendingBlock:^{
             [self changeStatus:AVIMClientStatusClosing];

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -82,9 +82,9 @@ typedef NS_OPTIONS(NSUInteger, LCIMSessionConfigOptions) {
 
 @implementation AVIMClient {
     
-    id<AVIMClientDelegate> _delegate;
+    __weak id<AVIMClientDelegate> _delegate;
     
-    id<AVIMSignatureDataSource> _signatureDataSource;
+    __weak id<AVIMSignatureDataSource> _signatureDataSource;
     
     AVIMWebSocketWrapper *_socketWrapper;
     

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -80,6 +80,19 @@ static BOOL AVIMClientHasInstantiated = NO;
     
     dispatch_once(&onceToken, ^{
         imClientQueue = dispatch_queue_create("cn.leancloud.im", DISPATCH_QUEUE_SERIAL);
+/*
+ Add specific to 'imClientQueue'
+ */
+///
+#ifdef DEBUG
+        imClientQueue_specific_key = (__bridge void *)imClientQueue;
+        imClientQueue_specific_value = (__bridge void *)imClientQueue;
+        dispatch_queue_set_specific(imClientQueue,
+                                    imClientQueue_specific_key,
+                                    imClientQueue_specific_value,
+                                    NULL);
+#endif
+///
     });
 }
 

--- a/AVOS/AVOSCloudIM/AVIMClientOpenOption.h
+++ b/AVOS/AVOSCloudIM/AVIMClientOpenOption.h
@@ -10,6 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__deprecated_msg("Deprecated after v8.2.0")
 @interface AVIMClientOpenOption : NSObject
 
 @property (nonatomic, assign) BOOL force;

--- a/AVOS/AVOSCloudIM/AVIMClient_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMClient_Internal.h
@@ -11,20 +11,6 @@
 #import "LCIMConversationCache.h"
 #import "AVIMConversation_Internal.h"
 
-/*
- Use dispatch's specific to Assert ('current queue' == 'imClient')
- */
-///
-#ifdef DEBUG
-
-static void *imClientQueue_specific_key;
-static void *imClientQueue_specific_value;
-
-#define AssertRunInIMClientQueue NSAssert(dispatch_get_specific(imClientQueue_specific_key) == imClientQueue_specific_value, @"This internal method should run in `imClientQueue`.")
-
-#endif
-///
-
 @interface AVIMClient ()
 
 + (NSMutableDictionary *)_userOptions;
@@ -32,29 +18,14 @@ static void *imClientQueue_specific_value;
 + (BOOL)checkErrorForSignature:(AVIMSignature *)signature command:(AVIMGenericCommand *)command;
 + (void)_assertClientIdsIsValid:(NSArray *)clientIds;
 
-@property (nonatomic, copy)   NSString              *clientId;
-@property (nonatomic, assign) AVIMClientStatus       status;
-@property (nonatomic, strong) AVIMWebSocketWrapper  *socketWrapper;
-
 /// Hold the staged message, which is sent by current client and waiting for receipt.
 @property (nonatomic, strong) NSMutableDictionary   *stagedMessages;
-
-@property (nonatomic, strong) AVIMGenericCommand    *openCommand;
-@property (nonatomic, assign) int32_t                openTimes;
-@property (nonatomic, copy)   NSString              *tag;
-@property (nonatomic, assign) BOOL                   onceOpened;
-
-@property (nonatomic, assign) int64_t                lastPatchTimestamp;
-@property (nonatomic, assign) int64_t                lastUnreadTimestamp;
-
 @property (nonatomic, strong) LCIMConversationCache *conversationCache;
 
 /**
  Conversations's Memory Cache Container.
  */
 @property (nonatomic, strong) NSMutableDictionary *conversationDictionary;
-
-- (void)setStatus:(AVIMClientStatus)status;
 
 - (void)sendCommand:(AVIMGenericCommand *)command;
 

--- a/AVOS/AVOSCloudIM/AVIMClient_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMClient_Internal.h
@@ -29,11 +29,6 @@
 
 - (void)sendCommand:(AVIMGenericCommand *)command;
 
-- (AVIMSignature *)signatureWithClientId:(NSString *)clientId
-                          conversationId:(NSString *)conversationId
-                                  action:(NSString *)action
-                       actionOnClientIds:(NSArray *)clientIds;
-
 - (void)stageMessage:(AVIMMessage *)message;
 - (void)unstageMessageForId:(NSString *)messageId;
 - (AVIMMessage *)stagedMessageForId:(NSString *)messageId;
@@ -43,6 +38,14 @@
 - (void)updateReceipt:(NSDate *)date
        ofConversation:(AVIMConversation *)conversation
                forKey:(NSString *)key;
+
+/*
+ Signature
+ */
+- (AVIMSignature *)getSignatureByDataSourceWithAction:(NSString *)action
+                                       conversationId:(NSString *)conversationId
+                                            clientIds:(NSArray<NSString *> *)clientIds
+__attribute__((warn_unused_result));
 
 /*
  Conversation Memory Cache

--- a/AVOS/AVOSCloudIM/AVIMClient_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMClient_Internal.h
@@ -11,6 +11,20 @@
 #import "LCIMConversationCache.h"
 #import "AVIMConversation_Internal.h"
 
+/*
+ Use dispatch's specific to Assert ('current queue' == 'imClient')
+ */
+///
+#ifdef DEBUG
+
+static void *imClientQueue_specific_key;
+static void *imClientQueue_specific_value;
+
+#define AssertRunInIMClientQueue NSAssert(dispatch_get_specific(imClientQueue_specific_key) == imClientQueue_specific_value, @"This internal method should run in `imClientQueue`.")
+
+#endif
+///
+
 @interface AVIMClient ()
 
 + (NSMutableDictionary *)_userOptions;

--- a/AVOS/AVOSCloudIM/AVIMClient_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMClient_Internal.h
@@ -51,4 +51,17 @@
                               orNewWithType:(LCIMConvType)convType
 __attribute__((warn_unused_result));
 
+/*
+ Thread-unsafe
+ */
+///
+
+- (AVIMClientStatus)threadUnsafe_status
+__attribute__((warn_unused_result));
+
+- (id<AVIMClientDelegate>)threadUnsafe_delegate
+__attribute__((warn_unused_result));
+
+///
+
 @end

--- a/AVOS/AVOSCloudIM/AVIMConversation.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation.h
@@ -191,8 +191,18 @@ typedef NS_ENUM(NSInteger, AVIMMessageQueryDirection) {
  */
 @property (nonatomic, weak, readonly, nullable)   AVIMClient   *imClient;
 
+/**
+ Unavailable.
+ 
+ @return Exception.
+ */
 + (instancetype)new NS_UNAVAILABLE;
 
+/**
+ Unavailable.
+ 
+ @return Exception.
+ */
 - (instancetype)init NS_UNAVAILABLE;
 
 /**

--- a/AVOS/AVOSCloudIM/AVIMConversation.m
+++ b/AVOS/AVOSCloudIM/AVIMConversation.m
@@ -310,7 +310,7 @@ static dispatch_queue_t messageCacheOperationQueue;
 }
 
 - (void)postUpdateNotificationForKey:(NSString *)key {
-    id  delegate = self.imClient.delegate;
+    id  delegate = self.imClient.threadUnsafe_delegate;
     SEL selector = @selector(conversation:didUpdateForKey:);
 
     if (![delegate respondsToSelector:selector])
@@ -872,7 +872,7 @@ static dispatch_queue_t messageCacheOperationQueue;
 {
     message.clientId = _imClient.clientId;
     message.conversationId = _conversationId;
-    if (self.imClient.status != AVIMClientStatusOpened) {
+    if (self.imClient.threadUnsafe_status != AVIMClientStatusOpened) {
         message.status = AVIMMessageStatusFailed;
         NSError *error = [AVIMErrorUtil errorWithCode:kAVIMErrorClientNotOpen reason:@"You can only send message when the status of the client is opened."];
         [AVIMBlockHelper callBooleanResultBlock:callback error:error];
@@ -1544,7 +1544,7 @@ static dispatch_queue_t messageCacheOperationQueue;
 {
     limit = [self.class validLimit:limit];
     
-    BOOL socketOpened = (self.imClient.status == AVIMClientStatusOpened);
+    BOOL socketOpened = (self.imClient.threadUnsafe_status == AVIMClientStatusOpened);
     
     /* if disable query from cache, then only query from server. */
     if (!self.imClient.messageQueryCacheEnabled) {
@@ -1726,7 +1726,7 @@ static dispatch_queue_t messageCacheOperationQueue;
         /*
          * If message is continuous or socket connect is not opened, return fetched messages directly.
          */
-        BOOL socketOpened = (self.imClient.status == AVIMClientStatusOpened);
+        BOOL socketOpened = (self.imClient.threadUnsafe_status == AVIMClientStatusOpened);
         
         if ((continuous && cachedMessages.count == limit) ||
             !socketOpened) {

--- a/AVOS/AVOSCloudIM/AVIMConversation.m
+++ b/AVOS/AVOSCloudIM/AVIMConversation.m
@@ -587,9 +587,13 @@ static dispatch_queue_t messageCacheOperationQueue;
         command.cid = self.conversationId;
         command.mArray = [NSMutableArray arrayWithArray:clientIds];
         NSString  *actionString = [AVIMCommandFormatter signatureActionForKey:genericCommand.op];
-        NSString *clientIdString = [NSString stringWithFormat:@"%@",genericCommand.peerId];
+        
         NSArray *clientIds = [command.mArray copy];
-        AVIMSignature *signature = [_imClient signatureWithClientId:clientIdString conversationId:command.cid action:actionString actionOnClientIds:clientIds];
+        
+        AVIMSignature *signature = [_imClient getSignatureByDataSourceWithAction:actionString
+                                                                  conversationId:command.cid
+                                                                       clientIds:clientIds];
+        
         [genericCommand avim_addRequiredKeyWithCommand:command];
         [genericCommand avim_addRequiredKeyForConvMessageWithSignature:signature];
         if ([AVIMClient checkErrorForSignature:signature command:genericCommand]) {
@@ -630,10 +634,13 @@ static dispatch_queue_t messageCacheOperationQueue;
         command.cid = self.conversationId;
         command.mArray = [NSMutableArray arrayWithArray:clientIds];
         NSString *actionString = [AVIMCommandFormatter signatureActionForKey:genericCommand.op];
-        NSString *clientIdString = [NSString stringWithFormat:@"%@",genericCommand.peerId];
+        
         NSArray *clientIds = [command.mArray copy];
         
-        AVIMSignature *signature = [_imClient signatureWithClientId:clientIdString conversationId:command.cid action:actionString actionOnClientIds:clientIds];
+        AVIMSignature *signature = [_imClient getSignatureByDataSourceWithAction:actionString
+                                                                  conversationId:command.cid
+                                                                       clientIds:clientIds];
+        
         [genericCommand avim_addRequiredKeyWithCommand:command];
         [genericCommand avim_addRequiredKeyForConvMessageWithSignature:signature];
         if ([AVIMClient checkErrorForSignature:signature command:genericCommand]) {

--- a/AVOS/AVOSCloudIM/Utilities/AVIMErrorUtil.h
+++ b/AVOS/AVOSCloudIM/Utilities/AVIMErrorUtil.h
@@ -8,6 +8,16 @@
 
 #import <Foundation/Foundation.h>
 
+extern NSString * const kLeanCloudIMErrorDomain;
+
+typedef NS_ENUM(NSInteger, LeanCloudIMErrorCode) {
+    
+    /*
+     IM Command Timeout
+     */
+    LeanCloudIMErrorCode_CommandTimeout = -20000,
+};
+
 @interface AVIMErrorUtil : NSObject
 + (NSError *)errorWithCode:(NSInteger)code reason:(NSString *)reason;
 @end

--- a/AVOS/AVOSCloudIM/Utilities/AVIMErrorUtil.h
+++ b/AVOS/AVOSCloudIM/Utilities/AVIMErrorUtil.h
@@ -13,6 +13,10 @@ extern NSString * const kLeanCloudIMErrorDomain;
 typedef NS_ENUM(NSInteger, LeanCloudIMErrorCode) {
     
     /*
+     IM Module Error Code Number's Style is '-2XXXX'
+     */
+    
+    /*
      IM Command Timeout
      */
     LeanCloudIMErrorCode_CommandTimeout = -20000,

--- a/AVOS/AVOSCloudIM/Utilities/AVIMErrorUtil.m
+++ b/AVOS/AVOSCloudIM/Utilities/AVIMErrorUtil.m
@@ -9,6 +9,8 @@
 #import "AVIMErrorUtil.h"
 #import "AVIMCommon.h"
 
+NSString * const kLeanCloudIMErrorDomain = @"LeanCloudIMErrorDomain";
+
 NSString *AVOSCloudIMErrorDomain = @"AVOSCloudIMErrorDomain";
 
 @implementation AVIMErrorUtil

--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -655,8 +655,6 @@ NSString *const AVIMProtocolPROTOBUF3 = @"lc.protobuf2.3";
         return;
     }
     
-    AVLoggerInfo(AVLoggerDomainIM, LCIM_OUT_COMMAND_LOG_FORMAT, [genericCommand avim_description]);
-    
     AVIMCommandResultBlock callback = [genericCommand callback];
     
     BOOL needResponse = [genericCommand needResponse];
@@ -721,6 +719,8 @@ NSString *const AVIMProtocolPROTOBUF3 = @"lc.protobuf2.3";
             callback(genericCommand, nil, nil);
         }
     }
+    
+    AVLoggerInfo(AVLoggerDomainIM, LCIM_OUT_COMMAND_LOG_FORMAT, [genericCommand avim_description]);
     
     [webSocket send:data];
 }

--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -1262,10 +1262,15 @@ NSString *const AVIMProtocolPROTOBUF3 = @"lc.protobuf2.3";
         
         if (callback) {
             
-            NSError *error = [AVIMErrorUtil errorWithCode:kAVIMErrorTimeout
-                                                   reason:@"Request Timeout."];
+            NSString *reason = @"Command Timeout.";
             
-            callback(command, nil, error);
+            NSDictionary *info = @{ @"reason" : reason };
+            
+            NSError *aError = [NSError errorWithDomain:kLeanCloudIMErrorDomain
+                                                  code:LeanCloudIMErrorCode_CommandTimeout
+                                              userInfo:info];
+            
+            callback(command, nil, aError);
         }
     }
     

--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -924,16 +924,18 @@ NSString *const AVIMProtocolPROTOBUF3 = @"lc.protobuf2.3";
         
         if (outCommand) {
             
+            NSError *inError = nil;
+            
             if ([inCommand avim_hasError]) {
                 
-                error = [inCommand avim_errorObject];
+                inError = [inCommand avim_errorObject];
             }
             
             AVIMCommandResultBlock callback = outCommand.callback;
             
             if (callback) {
                 
-                callback(outCommand, inCommand, error);
+                callback(outCommand, inCommand, inError);
                 
                 /* 另外，对于情景：单点登录, 由于未上传 deviceToken 就 open，如果用户没有 force 登录，会报错,
                  详见 https://leanticket.cn/t/leancloud/925
@@ -945,7 +947,7 @@ NSString *const AVIMProtocolPROTOBUF3 = @"lc.protobuf2.3";
                  这种情况不仅要告知用户登录失败，同时也要也要在 `-[AVIMClient processSessionCommand:]` 中统一进行异常处理，
                  触发代理方法 `-client:didOfflineWithError:` 告知用户需要将 force 设为 YES。
                  */
-                if (inCommand.hasSessionMessage && error) {
+                if (inCommand.hasSessionMessage && inError) {
                     
                     notifyCommand_block();
                 }

--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -510,7 +510,7 @@ NSString *const AVIMProtocolPROTOBUF3 = @"lc.protobuf2.3";
                 
             } else {
                 
-                [self postNotificationName:AVIM_NOTIFICATION_WEBSOCKET_ERROR
+                [self postNotificationName:AVIM_NOTIFICATION_WEBSOCKET_CLOSED
                                      error:error];
             }
             
@@ -878,7 +878,7 @@ NSString *const AVIMProtocolPROTOBUF3 = @"lc.protobuf2.3";
         
     } else {
         
-        [self postNotificationName:AVIM_NOTIFICATION_WEBSOCKET_ERROR
+        [self postNotificationName:AVIM_NOTIFICATION_WEBSOCKET_CLOSED
                              error:error];
         
         if (_needReconnect) {
@@ -1305,6 +1305,8 @@ NSString *const AVIMProtocolPROTOBUF3 = @"lc.protobuf2.3";
          */
         
         _webSocket.delegate = nil;
+        
+        [_webSocket close];
         
         _webSocket = nil;
     }

--- a/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
+++ b/AVOS/AVOSCloudIM/WebSocket/AVIMWebSocketWrapper.m
@@ -38,7 +38,11 @@
     @"------ END --------------------------------\n" \
     @"\n"
 
+#ifdef DEBUG
+
 #define AssertRunInSerialQueue NSAssert(dispatch_get_specific(_serialQueue_specific_key) == _serialQueue_specific_value, @"This internal method should run in `_serialQueue`.")
+
+#endif
 
 static NSTimeInterval AVIMWebSocketDefaultTimeoutInterval = 30.0;
 

--- a/AVOS/AVOSCloudTests/Swift/AVErrorUtilsTestCase.swift
+++ b/AVOS/AVOSCloudTests/Swift/AVErrorUtilsTestCase.swift
@@ -1,0 +1,95 @@
+//
+//  AVErrorUtilsTestCase.swift
+//  AVOS
+//
+//  Created by zapcannon87 on 16/01/2018.
+//  Copyright © 2018 LeanCloud Inc. All rights reserved.
+//
+
+import XCTest
+
+class AVErrorUtilsTestCase: LCTestBase {
+    
+    func testErrorFromJSON() {
+        
+        let dic1: [String : Any] = [
+            "code" : 0,
+            "error" : "error"
+        ]
+        
+        XCTAssertNotNil(AVErrorUtils.error(fromJSON: dic1))
+        
+        let dic2: [String : Any] = [
+            "code" : "error",
+            "error" : "error"
+        ]
+        
+        XCTAssertNil(AVErrorUtils.error(fromJSON: dic2))
+        
+        let dic3: [String : Any] = [
+            "code" : 0,
+            "error" : 0
+        ]
+        
+        XCTAssertNil(AVErrorUtils.error(fromJSON: dic3))
+        
+        let dic4: [String : Any] = [
+            "code" : 0
+        ]
+        
+        XCTAssertNil(AVErrorUtils.error(fromJSON: dic4))
+        
+        let dic5: [String : Any] = [
+            "error" : "error"
+        ]
+        
+        XCTAssertNil(AVErrorUtils.error(fromJSON: dic5))
+        
+        let dic6: [String : Any] = [:]
+        
+        XCTAssertNil(AVErrorUtils.error(fromJSON: dic6))
+        
+        let dic7: [String : Any]? = nil
+        
+        XCTAssertNil(AVErrorUtils.error(fromJSON: dic7))
+        
+        let dic8: [String : Any] = [
+            "a" : dic1
+        ]
+        
+        XCTAssertNotNil(AVErrorUtils.error(fromJSON: dic8))
+        
+        let dic9: [String : Any] = [
+            "a" : [dic1]
+        ]
+        
+        XCTAssertNotNil(AVErrorUtils.error(fromJSON: dic9))
+        
+        let dic10: [String : Any] = [
+            "a" : ["b" : dic1]
+        ]
+        
+        XCTAssertNotNil(AVErrorUtils.error(fromJSON: dic10))
+        
+        let arr1: [Any] = [dic1]
+        
+        XCTAssertNotNil(AVErrorUtils.error(fromJSON: arr1))
+        
+        let arr2: [Any] = [dic2, arr1]
+        
+        XCTAssertNotNil(AVErrorUtils.error(fromJSON: arr2))
+        
+        let arr3: [Any] = [dic2, dic10]
+        
+        XCTAssertNotNil(AVErrorUtils.error(fromJSON: arr3))
+        
+        let arr4: [Any] = []
+        
+        XCTAssertNil(AVErrorUtils.error(fromJSON: arr4))
+        
+        let arr5: [Any]? = nil
+        
+        XCTAssertNil(AVErrorUtils.error(fromJSON: arr5))
+    }
+
+}

--- a/AVOS/TestBase/Swift/Bridging-Header/AVOSCloud-iOSTests-Bridging-Header.h
+++ b/AVOS/TestBase/Swift/Bridging-Header/AVOSCloud-iOSTests-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "AVOSCloud.h"
+#import "AVErrorUtils.h"


### PR DESCRIPTION
* 对 `AVIMWebSocketWrapper`  的通知进行了改动，Error 的通知合并到 Closed 的通知中，不再有 Error 的通知
* 对 `AVIMClient` 进行了部分重构，主要是针对该类中的 property 以及相关的 Method
* `AVIMClient` 将 `AVIMClientDelegate` 中和 status 有关的协议变为 required ，重命名了其中一个方法
* `AVIMClient` 弃用 `AVIMClientOpenOption` 类，Open Option 参数的类型变更为 `NS_OPTIONS`
* SSL Pinning enabled 修改默认参数为 false

@tang3w 