### PR TITLE
Merge AVIMConversationDelegate into AVIMClientDelegate

### DIFF
--- a/AVOS/AVOSCloud/UserAgent.h
+++ b/AVOS/AVOSCloud/UserAgent.h
@@ -1,1 +1,1 @@
-#define SDK_VERSION @"v9.0.2"
+#define SDK_VERSION @"v10.0.0"

--- a/AVOS/AVOSCloud/UserAgent.h
+++ b/AVOS/AVOSCloud/UserAgent.h
@@ -1,1 +1,1 @@
-#define SDK_VERSION @"v9.0.1"
+#define SDK_VERSION @"v9.0.2"

--- a/AVOS/AVOSCloudIM/AVIMClient.h
+++ b/AVOS/AVOSCloudIM/AVIMClient.h
@@ -484,6 +484,14 @@ __attribute__((warn_unused_result));
  */
 - (void)conversation:(AVIMConversation *)conversation messageDelivered:(AVIMMessage *)message;
 
+/**
+ Callback which called when a message has been updated.
+ 
+ @param conversation The conversation which the message belongs to.
+ @param message      The new message which has been updated.
+ */
+- (void)conversation:(AVIMConversation *)conversation messageHasBeenUpdated:(AVIMMessage *)message;
+
 /*!
  对话中有新成员加入时所有成员都会收到这一通知。
  @param conversation － 所属对话

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -2394,7 +2394,7 @@ typedef NS_OPTIONS(NSUInteger, LCIMSessionConfigOptions) {
         
         AVIMMessage *message = [[self messageCacheStoreForConversationId:conversationId] messageForId:messageId];
         
-        id <AVIMClientDelegate> delegate = self.delegate;
+        id <AVIMClientDelegate> delegate = _delegate;
         
         if (conv && message && delegate && [delegate respondsToSelector:@selector(conversation:messageHasBeenUpdated:)]) {
             

--- a/AVOS/AVOSCloudIM/AVIMClient.m
+++ b/AVOS/AVOSCloudIM/AVIMClient.m
@@ -2344,7 +2344,10 @@ typedef NS_OPTIONS(NSUInteger, LCIMSessionConfigOptions) {
     }
 }
 
-- (void)processMessagePatchCommand:(AVIMPatchCommand *)command {
+- (void)processMessagePatchCommand:(AVIMPatchCommand *)command
+{
+    AssertRunInIMClientQueue;
+    
     NSArray<AVIMPatchItem *> *patchItems = command.patchesArray;
 
     for (AVIMPatchItem *patchItem in patchItems) {
@@ -2381,9 +2384,32 @@ typedef NS_OPTIONS(NSUInteger, LCIMSessionConfigOptions) {
     [[NSNotificationCenter defaultCenter] postNotificationName:LCIMConversationMessagePatchNotification
                                                         object:self
                                                       userInfo:userInfo];
+    
+    NSString *conversationId = patchItem.cid;
+    NSString *messageId = patchItem.mid;
+    
+    if (conversationId && messageId) {
+        
+        AVIMConversation *conv = [self conversationForId:conversationId];
+        
+        AVIMMessage *message = [[self messageCacheStoreForConversationId:conversationId] messageForId:messageId];
+        
+        id <AVIMClientDelegate> delegate = self.delegate;
+        
+        if (conv && message && delegate && [delegate respondsToSelector:@selector(conversation:messageHasBeenUpdated:)]) {
+            
+            dispatch_async(dispatch_get_main_queue(), ^{
+                
+                [delegate conversation:conv messageHasBeenUpdated:message];
+            });
+        }
+    }
 }
 
-- (void)sendACKForPatchCommand:(AVIMGenericCommand *)inCommand {
+- (void)sendACKForPatchCommand:(AVIMGenericCommand *)inCommand
+{
+    AssertRunInIMClientQueue;
+    
     int64_t lastPatchTimestamp = _lastPatchTimestamp;
 
     if (!lastPatchTimestamp)

--- a/AVOS/AVOSCloudIM/AVIMConversation.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation.h
@@ -60,21 +60,6 @@ typedef NS_ENUM(NSInteger, AVIMMessageQueryDirection) {
     AVIMMessageQueryDirectionFromOldToNew
 };
 
-/**
- A protocol defines callbacks of events related to conversation.
- */
-@protocol AVIMConversationDelegate <NSObject>
-
-/**
- Callback which called when a message has been updated.
-
- @param conversation The conversation which the message belongs to.
- @param message      The new message which has been updated.
- */
-- (void)conversation:(AVIMConversation *)conversation messageHasBeenUpdated:(AVIMMessage *)message;
-
-@end
-
 @interface AVIMConversation : NSObject
 
 /**
@@ -204,20 +189,6 @@ typedef NS_ENUM(NSInteger, AVIMMessageQueryDirection) {
  @return Exception.
  */
 - (instancetype)init NS_UNAVAILABLE;
-
-/**
- Add a delegate which listens conversation events.
-
- @param delegate An object which listens conversation events.
- */
-- (void)addDelegate:(id<AVIMConversationDelegate>)delegate;
-
-/**
- Remove a delegate which is listening conversation events.
-
- @param delegate The delegate object you want to remove.
- */
-- (void)removeDelegate:(id<AVIMConversationDelegate>)delegate;
 
 /**
  * Add custom property for conversation.

--- a/AVOS/AVOSCloudIM/AVIMConversation_Internal.h
+++ b/AVOS/AVOSCloudIM/AVIMConversation_Internal.h
@@ -120,8 +120,6 @@ typedef NS_ENUM(NSUInteger, LCIMConvType) {
  */
 @property (nonatomic, strong) NSDictionary *rawDataDic;
 
-@property (nonatomic, strong) NSHashTable<id<AVIMConversationDelegate>> *delegates;
-
 + (instancetype)newWithConversationId:(NSString *)conversationId
                              convType:(LCIMConvType)convType
                                client:(AVIMClient *)client;

--- a/AVOSCloud.podspec
+++ b/AVOSCloud.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AVOSCloud'
-  s.version  = '9.0.1'
+  s.version  = '9.0.2'
   s.homepage = 'https://leancloud.cn/'
   s.summary  = 'LeanCloud Objective-C SDK'
   s.authors  = 'LeanCloud'

--- a/AVOSCloud.podspec
+++ b/AVOSCloud.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AVOSCloud'
-  s.version  = '9.0.2'
+  s.version  = '10.0.0'
   s.homepage = 'https://leancloud.cn/'
   s.summary  = 'LeanCloud Objective-C SDK'
   s.authors  = 'LeanCloud'

--- a/AVOSCloudIM.podspec
+++ b/AVOSCloudIM.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AVOSCloudIM'
-  s.version  = '9.0.2'
+  s.version  = '10.0.0'
   s.homepage = 'https://leancloud.cn/'
   s.summary  = 'LeanCloud IM Objective-C SDK'
   s.authors  = 'LeanCloud'

--- a/AVOSCloudIM.podspec
+++ b/AVOSCloudIM.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AVOSCloudIM'
-  s.version  = '9.0.1'
+  s.version  = '9.0.2'
   s.homepage = 'https://leancloud.cn/'
   s.summary  = 'LeanCloud IM Objective-C SDK'
   s.authors  = 'LeanCloud'

--- a/AVOSCloudIMGroupChat.podspec
+++ b/AVOSCloudIMGroupChat.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AVOSCloudIMGroupChat'
-  s.version  = '9.0.2'
+  s.version  = '10.0.0'
   s.homepage = 'https://leancloud.cn/'
   s.summary  = 'Group Chat Extension of LeanCloud IM Objective-C SDK'
   s.authors  = 'LeanCloud'

--- a/AVOSCloudIMGroupChat.podspec
+++ b/AVOSCloudIMGroupChat.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AVOSCloudIMGroupChat'
-  s.version  = '9.0.1'
+  s.version  = '9.0.2'
   s.homepage = 'https://leancloud.cn/'
   s.summary  = 'Group Chat Extension of LeanCloud IM Objective-C SDK'
   s.authors  = 'LeanCloud'

--- a/AVOSCloudLiveQuery.podspec
+++ b/AVOSCloudLiveQuery.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AVOSCloudLiveQuery'
-  s.version  = '9.0.2'
+  s.version  = '10.0.0'
   s.homepage = 'https://leancloud.cn/'
   s.summary  = 'LeanCloud LiveQuery Objective-C SDK'
   s.authors  = 'LeanCloud'

--- a/AVOSCloudLiveQuery.podspec
+++ b/AVOSCloudLiveQuery.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'AVOSCloudLiveQuery'
-  s.version  = '9.0.1'
+  s.version  = '9.0.2'
   s.homepage = 'https://leancloud.cn/'
   s.summary  = 'LeanCloud LiveQuery Objective-C SDK'
   s.authors  = 'LeanCloud'


### PR DESCRIPTION
相关工单：https://leanticket.cn/tickets/16149

在原本的设计中，`-[conversation:messageHasBeenUpdated:]` 方法是被 AVIMConversation 的实例调用的。但是这种设计存在一个问题，当 clientA 的同一条消息的发送以及修改操作间隔很短的时候，如果 clientB 没有该 conversation 的实例或者该实例的 delegate 没有被设置，可能就会出现 `-[conversation:messageHasBeenUpdated:]` 不会被触发的 bug。

该 bug 的原因是，用户在 `-[conversation:didReceiveCommonMessage:]` 方法中为 conversation 设置 delegate 的线程是主线程，而 `-[conversation:messageHasBeenUpdated:]` 方法被调用的线程则是 IM 的内部线程，当两条命令间隔很短的时候，conversation 的 delegate 的设置操作和 `-[conversation:messageHasBeenUpdated:]` 被调用的操作的顺序是无法保证的。

综上所述，我认为最好的解决方式就是把 AVIMConversationDelegate 中的方法合并到 AVIMClientDelegate 中，client 的 delegate 可以保证在 open 操作前被设置。

@tang3w 