### PR TITLE
init _cacheQueue when AVCacheManager init.

### DIFF
--- a/AVOS/AVOSCloud/Cache/AVCacheManager.m
+++ b/AVOS/AVOSCloud/Cache/AVCacheManager.m
@@ -34,6 +34,14 @@
     return _sharedInstance;
 }
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _cacheQueue = dispatch_queue_create("avos.paas.cacheQueue", DISPATCH_QUEUE_SERIAL);
+    }
+    return self;
+}
+
 #pragma mark - Accessors
 + (NSString *)path {
     return [AVPersistenceUtils avCacheDirectory];
@@ -44,13 +52,6 @@
         _diskCachePath = [AVCacheManager path];
     }
     return _diskCachePath;
-}
-
-- (dispatch_queue_t)cacheQueue {
-    if (!_cacheQueue) {
-        _cacheQueue = dispatch_queue_create("avos.paas.cacheQueue", DISPATCH_QUEUE_SERIAL);
-    }
-    return _cacheQueue;
 }
 
 - (NSString *)pathForKey:(NSString *)key {


### PR DESCRIPTION
Thanks for the amazing framework to speed up the development.
I found some crash like these:
```
Crashed: avos.paas.completionQueue
0  libdispatch.dylib              0x1a31f01bc _os_object_retain$VARIANT$armv81 + 64
1  AVOSCloud                      0x10104f0a0 -[AVCacheManager saveJSON:forKey:] (AVCacheManager.m:95)
2  AVOSCloud                      0x101076274 __59-[AVPaasClient performRequest:saveResult:block:retryTimes:]_block_invoke (AVPaasClient.m:567)
3  AVOSCloud                      0x101076cd4 __52-[AVPaasClient performRequest:success:failure:wait:]_block_invoke (AVPaasClient.m:696)
4  AVOSCloud                      0x1010bb12c __72-[LCURLSessionManagerTaskDelegate URLSession:task:didCompleteWithError:]_block_invoke_2.125 (LCURLSessionManager.m:308)
5  libdispatch.dylib              0x1a32216c8 _dispatch_call_block_and_release + 24
6  libdispatch.dylib              0x1a3222484 _dispatch_client_callout + 16
7  libdispatch.dylib              0x1a31f8ebc _dispatch_continuation_pop$VARIANT$armv81 + 588
8  libdispatch.dylib              0x1a31f84e8 _dispatch_async_redirect_invoke + 592
9  libdispatch.dylib              0x1a3204aec _dispatch_root_queue_drain + 344
10 libdispatch.dylib              0x1a320534c _dispatch_worker_thread2 + 116
11 libsystem_pthread.dylib        0x1a340517c _pthread_wqthread + 472
12 libsystem_pthread.dylib        0x1a3407cec start_wqthread + 4
```

With google I found the solution below:
[https://www.jianshu.com/p/18eb681ef218](https://www.jianshu.com/p/18eb681ef218)
It may help.

